### PR TITLE
Simplify logic of iterutils.chunked

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -152,7 +152,7 @@ def chunked(src, size, count=None, **kw):
     if count is None:
         return list(chunk_iter)
     else:
-        return list(islice(chunk_iter, count))
+        return list(itertools.islice(chunk_iter, count))
 
 
 def chunked_iter(src, size, **kw):

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -151,12 +151,8 @@ def chunked(src, size, count=None, **kw):
     chunk_iter = chunked_iter(src, size, **kw)
     if count is None:
         return list(chunk_iter)
-    ret = []
-    for chunk in chunk_iter:
-        if len(ret) >= count:
-            return ret
-        ret.append(chunk)
-    return ret
+    else:
+        return list(islice(chunk_iter, count))
 
 
 def chunked_iter(src, size, **kw):


### PR DESCRIPTION
Rather than building and calculating a new list when setting a limit to
the items returned by `iterutils.chunked`, `itertools.islice` can be
used to reduce the code and take advantage of any optimizations in the
itertools module.