### PR TITLE
setutils: Add UniverseSet(), a virtual set containing "all" items

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -8,6 +8,8 @@ of this, sets are not indexable, i.e, ``my_set[8]`` will raise an
 :exc:`TypeError`. The :class:`IndexedSet` type remedies both of these
 issues without compromising on the excellent complexity
 characteristics of Python's built-in set implementation.
+The :class:`UniverseSet` type extends python's finite set implementation to
+infinite sets by keeping track of a finite coset of items not in the set.
 """
 
 from __future__ import print_function
@@ -419,6 +421,131 @@ class IndexedSet(MutableSet):
         except KeyError:
             cn = self.__class__.__name__
             raise ValueError('%r is not in %s' % (val, cn))
+
+
+class UniverseSet(object):
+    """This class acts like a set in most ways. However, all operations are
+    done against a virtual "Universe Set" that contains (initially) every value.
+    The main point of this kind of set is to exclude things from it specifically,
+    and possibly intersect it with a finite set (to yield a finite set) later.
+    """
+
+    def __init__(self, coset=()):
+        """The optional arg coset sets the initial coset (set of excluded items)
+        but is intended only for internal use. Better to use UniverseSet() - exclude_set."""
+        self.coset = set(coset)
+
+    def __and__(self, other):
+        if isinstance(other, UniverseSet):
+            return UniverseSet(self.coset | other.coset)
+        return other - self.coset
+    __rand__ = __and__
+
+    def __contains__(self, value):
+        return value not in self.coset
+
+    def __eq__(self, other):
+        if isinstance(other, UniverseSet):
+            return self.coset == other.coset
+        return False
+
+    def __le__(self, other):
+        return self.issubset(other)
+
+    def __ge__(self, other):
+        return self.issuperset(other)
+
+    def __lt__(self, other):
+        return self <= other and self != other
+
+    def __gt__(self, other):
+        return self >= other and self != other
+
+    def __or__(self, other):
+        if isinstance(other, UniverseSet):
+            return UniverseSet(self.coset & other.coset)
+        return UniverseSet(self.coset & other)
+    __ror__ = __or__
+
+    def __repr__(self):
+        return "<UniverseSet() - %s>" % repr(self.coset)
+    __str__ = __repr__
+
+    def __sub__(self, other):
+        if isinstance(other, UniverseSet):
+            return other.coset - self.coset
+        return UniverseSet(self.coset | other)
+
+    def __rsub__(self, other):
+        return other & self.coset
+
+    def __xor__(self, other):
+        if isinstance(other, UniverseSet):
+            return self.coset ^ other.coset
+        return UniverseSet(self.coset & other)
+    __rxor__ = __xor__
+
+    def add(self, value):
+        self.coset.discard(value)
+
+    def copy(self):
+        return UniverseSet(self.coset)
+
+    def difference(self, *others):
+        ret = self
+        for other in others:
+            ret -= other
+
+    def intersection(self, *others):
+        ret = self
+        for other in others:
+            ret &= other
+        return ret
+
+    def isdisjoint(self, other):
+        return not self & other
+
+    def issubset(self, other):
+        if isinstance(other, UniverseSet):
+            return other.coset.issubset(self.coset)
+        return False
+
+    def issuperset(self, other):
+        if isinstance(other, UniverseSet):
+            return self.coset.issubset(other.coset)
+        return self.coset.isdisjoint(other)
+
+    def pop(self):
+        raise ValueError("Cannot pop arbitrary value from infinite set")
+
+    def remove(self, value):
+        if value not in self:
+            raise KeyError(value)
+        self.discard(value)
+
+    def discard(self, value):
+        self.coset.add(value)
+
+    def symmetric_difference(self, other):
+        return self ^ other
+
+    def union(self, *others):
+        ret = self
+        for other in others:
+            ret |= other
+        return ret
+
+    def update(self, *others):
+        self.coset = self.union(*others).coset
+
+    # NOTE: We don't implement the following set methods:
+    #    clear
+    #    intersection_update
+    #    difference_update
+    #    symmetric_difference_update
+    # as they require (or may require) updating in-place from an infinite set
+    # to a finite one, which we can't do.
+
 
 
 # Tests of a manner


### PR DESCRIPTION
Ok, I admit this one's a bit esoteric. A `UniverseSet()` contains **literally every object possible** except ones you've specifically excluded. It's compatible with all set operations, eg:
```python
whitelist = UniverseSet()
whitelist -= blacklist
for value in whitelist & values:
  do_a_thing(value)
```

I haven't really had a good use for it (eg. the above could be written much simpler without it), but I thought it was really cool.
Maybe a more general "infinite set" where membership can be filtered by functions (eg. `PredicateSet(lambda x: int(x) == x and x >= 0)` would be the set of natural numbers)? Or maybe that should remain a more niche mathematics library thing?

What do you think? Is this possibly useful enough to consider including?

...actually now that I've written this, I think I'd prefer to not merge this. But I'll leave it up to you.