### PR TITLE
funcutils: Add partial_ordering(), decorator similar to functools.total_ordering()

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -98,6 +98,24 @@ def copy_function(orig, copy_dict=True):
     return ret
 
 
+def partial_ordering(cls):
+    """Class decorator. Similar to functools.total_ordering, except it
+    is used to define partial orderings (ie. it is possible that x is niether
+    greater than, equal to or less than y). It assumes the presence
+    of a <= (__le__) and >= (__ge__) method, but nothing else.
+    It will not override any existing additional comparison methods.
+    """
+    def __lt__(self, other): return self <= other and not self >= other
+    def __gt__(self, other): return self >= other and not self <= other
+    def __eq__(self, other): return self >= other and self <= other
+
+    if not hasattr(cls, '__lt__'): cls.__lt__ = __lt__
+    if not hasattr(cls, '__gt__'): cls.__gt__ = __gt__
+    if not hasattr(cls, '__eq__'): cls.__eq__ = __eq__
+
+    return cls
+
+
 class InstancePartial(functools.partial):
     """:class:`functools.partial` is a huge convenience for anyone
     working with Python's great first-class functions. It allows


### PR DESCRIPTION
Exactly what the description says. `total_ordering` is a great time-saver for implementing ordered types, but doesn't work correctly if your type is not strictly ordered. For example, suppose you wanted to define a set subtype where a < b only if a is a subset of b:

```python
>>> @partial_ordering
... class MySet(set):
...     def __le__(self, other):
...         return self.issubset(other)
...     def __ge__(self, other):
...         return self.issuperset(other)
... 
>>> a = MySet([1,2,3])
>>> b = MySet([1,2])
>>> c = MySet([1,2,4])
>>> b < a
True
>>> b > a
False
>>> b < c
True
>>> a < c
False
>>> c > a
False
```
