### PR TITLE
Handle teens in strutils.ordinalize

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -138,11 +138,14 @@ def ordinalize(number, ext_only=False):
 
     """
     numstr = unicode(number)
-    rdig, ext = numstr[-1:], ''
+    rdig, ext = numstr[-2:], ''
     if not rdig:
         return ''
-    if rdig in string.digits:
-        ext = _ORDINAL_MAP.get(rdig, 'th')
+    if rdig[-1] in string.digits:
+        if len(rdig) == 2 and rdig[0] == '1':
+            ext = 'th'
+        else:
+            ext = _ORDINAL_MAP.get(rdig[-1], 'th')
     if ext_only:
         return ext
     else:


### PR DESCRIPTION
This PR changes `strutils.ordinalize` to correctly handle numbers in the 1x decade. Prior to this numbers such as 12, and 111 were being incorrectly given the nd and st extensions respectively. This checks if the character before the last is a 1 and uses th as the extension.
