### PR TITLE
Missing docs for unique and unique_iter

### DIFF
--- a/docs/iterutils.rst
+++ b/docs/iterutils.rst
@@ -18,9 +18,10 @@ from the standard library.
 .. autofunction:: pairwise_iter
 .. autofunction:: windowed
 .. autofunction:: windowed_iter
-
 .. autofunction:: backoff
 .. autofunction:: backoff_iter
+.. autofunction:: unique
+.. autofunction:: unique_iter
 .. autofunction:: frange
 .. autofunction:: xfrange
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Went to go write the missing `unique` iterutil and saw it was already there, just undocumented.