### PR TITLE
Fixdoc

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -17,6 +17,8 @@ try:
 except NameError:
     # Python 3
     make_method = lambda desc, obj, obj_type: MethodType(desc, obj)
+    basestring = (str, bytes)  # Python 3 compat
+
 
 
 def get_module_callables(mod, ignore=None):

--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -37,12 +37,13 @@ The four `Standardized moments`_ are:
 
 For more information check out `the Moment article on Wikipedia`_.
 
-.. _moment: http://en.wikipedia.org/wiki/Moment_(mathematics)
-.. _Standardied moments: https://en.wikipedia.org/wiki/Standardized_moment
+.. _moment: https://en.wikipedia.org/wiki/Moment_(mathematics)
+.. _Standardized moments: https://en.wikipedia.org/wiki/Standardized_moment
 .. _Mean: https://en.wikipedia.org/wiki/Mean
 .. _Variance: https://en.wikipedia.org/wiki/Variance
 .. _Skewness: https://en.wikipedia.org/wiki/Skewness
 .. _Kurtosis: https://en.wikipedia.org/wiki/Kurtosis
+.. _the Moment article on Wikipedia: https://en.wikipedia.org/wiki/Moment_(mathematics)
 
 Keep in mind that while these moments can give a bit more insight into
 the shape and distribution of data, they do not guarantee a complete
@@ -67,6 +68,7 @@ dilemma. ``statsutils`` also includes several robust statistical methods:
 .. _Trimean: https://en.wikipedia.org/wiki/Trimean
 .. _Median Absolute Deviation: https://en.wikipedia.org/wiki/Median_absolute_deviation
 .. _Trimming: https://en.wikipedia.org/wiki/Trimmed_estimator
+
 
 Online and Offline Statistics
 -----------------------------


### PR DESCRIPTION
there was a couple of malformed links in `statutils.py`'s docstrings. 

Also, `funcutils` seems to have missing tests, because tox passed but a `get_module_callables()` misses `basestring` in py3