### PR TITLE
Stats add Z-Score

### DIFF
--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -351,6 +351,17 @@ class Stats(object):
             raise ValueError('expected q between 0.0 and 1.0, not %r' % q)
         return self._get_quantile(self._get_sorted_data(), q)
 
+    def get_zscore(self, value):
+        mean = self.mean
+        if self.std_dev == 0:
+            if value == mean:
+                return 0
+            if value > mean:
+                return float('inf')
+            if value < mean:
+                return float('-inf')
+        return (float(value) - mean) / self.std_dev
+
     def trim_relative(self, amount=0.15):
         """A utility function used to cut a proportion of values off each end
         of a list of values. This has the effect of limiting the

--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -156,7 +156,10 @@ class Stats(object):
 
     def clear_cache(self):
         for attr_name in self._prop_attr_names:
-            delattr(self, getattr(self.__class__, attr_name).internal_name)
+            attr_name = getattr(self.__class__, attr_name).internal_name
+            if not hasattr(self, attr_name):
+                continue
+            delattr(self, attr_name)
 
     def _calc_mean(self):
         """

--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -352,6 +352,10 @@ class Stats(object):
         return self._get_quantile(self._get_sorted_data(), q)
 
     def get_zscore(self, value):
+        """Get the z-score for *value* in the group. If the standard deviation
+        is 0, 0 inf or -inf will be returned to indicate whether the value is
+        equal to, greater than or below the group's mean.
+        """
         mean = self.mean
         if self.std_dev == 0:
             if value == mean:


### PR DESCRIPTION
This PR makes two changes to the `statsutils` module. The first fixes a bug in `clear_cache` which was throwing an error when `delattr` was being called for a non-existing attribute. The second adds a new method to the class which can be used to calculate the Z-Score of a value against the group represented by the Stats object. In the event that the standard deviation is 0, 0 inf or -inf are returned to indicate the values relation to the mean. This special case is noted in the method's doc string.

Example before the bug fix:
```
boltons > from boltons import statsutils
boltons > s = statsutils.Stats((1, 2, 3))
boltons > s.mean
2.0
boltons > s.data.append(1337)
boltons > s.mean
2.0
boltons > s.clear_cache()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "boltons/statsutils.py", line 157, in clear_cache
    delattr(self, getattr(self.__class__, attr_name).internal_name)
AttributeError: _kurtosis
boltons > 
```

Example after the bug fix:
```
boltons > from boltons import statsutils
boltons > s = statsutils.Stats((1, 2, 3))
boltons > s.mean
2.0
boltons > s.data.append(1337)
boltons > s.mean
2.0
boltons > s.clear_cache()
boltons > s.mean
335.75
```

Example of `Stats.get_zscore`:
```
boltons > from boltons import statsutils
boltons > s = statsutils.Stats((2, 4, 4, 4, 5, 5, 7, 9))
boltons > s.mean
5.0
boltons > s.get_zscore(4)
-0.5
boltons > s.get_zscore(9)
2.0
```

Thanks, boltons is awesome.