### PR TITLE
Fix is_uuid() on un-parsable types.

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -700,7 +700,7 @@ def is_uuid(obj, version=4):
     if not isinstance(obj, uuid.UUID):
         try:
             obj = uuid.UUID(obj)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, AttributeError):
             return False
     if version and obj.version != int(version):
         return False

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import uuid
+
 from boltons import strutils
 
 
@@ -14,3 +16,11 @@ def test_indent():
     to_indent = '\nabc\ndef\n\nxyz\n'
     ref = '\n  abc\n  def\n\n  xyz\n'
     assert strutils.indent(to_indent, '  ') == ref
+
+
+def test_is_uuid():
+    assert strutils.is_uuid(uuid.uuid4()) == True
+    assert strutils.is_uuid(uuid.uuid4(), version=1) == False
+    assert strutils.is_uuid(str(uuid.uuid4())) == True
+    assert strutils.is_uuid(str(uuid.uuid4()), version=1) == False
+    assert strutils.is_uuid(set('garbage')) == False


### PR DESCRIPTION
`boltons.strutils.is_uuid()` method raise an exception with garbage types. I expect here `is_uuid()` to return `False` for un-parsable types.

The first commit provide evidence of the unwanted behaviour.
The second commit provide a fix.