### PR TITLE
Add functions strpdate() and daterange(), which make working with date objects more convenient.

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -248,39 +248,27 @@ def relative_time(d, other=None, ndigits=0):
 
 
 def strpdate(string, format):
-    """Parse the date string according to the format in `format`.  Returns
-    a :class:`date` object.
+    """Parse the date string according to the format in `format`.  Returns a
+    :class:`date` object.  Internally, :meth:`datetime.strptime` is used to
+    parse the string and thus conversion specifiers for time fields (e.g. `%H`)
+    may be provided;  these will be parsed but ignored.
 
     Args:
         string (str): The date string to be parsed.
-        format (str): The :meth:`datetime.strptime` format string
-            describing how to parse the date string.
+        format (str): The `strptime()`-style date format string.
     Returns:
-        date: The parsed date object.
-
-    Raises :class:`ValueError` if :meth:`datetime.strptime` returns
-    a non-zero value in one of the hour, minute, second, or microsecond
-    fields.
+        datetime.date
 
     >>> strpdate('20160214', '%Y%m%d')
     datetime.date(2016, 2, 14)
     >>> strpdate('26/12 (2015)', '%d/%m (%Y)')
     datetime.date(2015, 12, 26)
     >>> strpdate('20151231 23:59:59', '%Y%m%d %H:%M:%S')
-    Traceback (most recent call last):
-        ...
-    ValueError: parsed date has non-zero time value(s)
-    >>> strpdate('20160101 00:00:00.000', '%Y%m%d %H:%M:%S.%f')
-    datetime.date(2016, 1, 1)
+    datetime.date(2015, 12, 31)
     >>> strpdate('20160101 00:00:00.001', '%Y%m%d %H:%M:%S.%f')
-    Traceback (most recent call last):
-        ...
-    ValueError: parsed date has non-zero time value(s)
+    datetime.date(2016, 1, 1)
     """
     whence = datetime.strptime(string, format)
-    time_fields = 'hour', 'minute', 'second', 'microsecond'
-    if not all(getattr(whence, attr) == 0 for attr in time_fields):
-        raise ValueError("parsed date has non-zero time value(s)")
     return whence.date()
 
 

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -272,7 +272,7 @@ def strpdate(string, format):
     return whence.date()
 
 
-def daterange(start, stop=None, step=1, inclusive=False):
+def daterange(start, stop=None, step=timedelta(days=1), inclusive=False):
     """Generator that yields a range of `date` objects.
 
     If `stop` is present, the final date produced will be the day before `stop`
@@ -305,6 +305,10 @@ def daterange(start, stop=None, step=1, inclusive=False):
     datetime.date(2015, 12, 27)
     datetime.date(2015, 12, 29)
     datetime.date(2015, 12, 31)
+
+    Care should be exercised when stop=None, as this will yield an infinite
+    sequence of dates:
+
     >>> for i, day in enumerate(daterange(new_year)):
     ...   if i > 4:  break
     ...   print(repr(day))
@@ -314,15 +318,14 @@ def daterange(start, stop=None, step=1, inclusive=False):
     datetime.date(2016, 1, 4)
     datetime.date(2016, 1, 5)
     """
-    assert isinstance(start, date)
-    assert stop is None or isinstance(stop, date)
-    if isinstance(step, int):
+    if not isinstance(start, date):
+        raise TypeError("start must be a 'date' object")
+    if stop and not isinstance(stop, date):
+        raise TypeError("stop must be either a 'date' object or None")
+    if not isinstance(step, timedelta):
         step = timedelta(days=step)
-    elif isinstance(step, timedelta):
-        if step.seconds > 0 or step.microseconds > 0:
-            raise ValueError("step must be given in terms of days")
-    else:
-        raise TypeError("step must be an 'int' or 'timedelta' object")
+    if step.seconds > 0 or step.microseconds > 0:
+        raise ValueError("step must be an integer number of days")
     if stop is None:
         finished = lambda t: False
     elif inclusive:


### PR DESCRIPTION
I've often wanted to use a `strptime()`-style format string to parse date values, and find that having a complimentary `strpdate()` function is clearer than writing e.g. ```datetime.strptime(val, '%Y-%m-%d').date()``` all over the place.

Also, iterating over date ranges can be quite awkward, because any date arithmetic requires the involvement of the dreaded `timedelta` class.