### PR TITLE
iterutils: optimize chunked_iter

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -218,17 +218,13 @@ def chunked_iter(src, size, **kw):
     postprocess = lambda chk: chk
     if isinstance(src, basestring):
         postprocess = lambda chk, _sep=type(src)(): _sep.join(chk)
-    cur_chunk = []
-    i = 0
-    for item in src:
-        cur_chunk.append(item)
-        i += 1
-        if i % size == 0:
-            yield postprocess(cur_chunk)
-            cur_chunk = []
-    if cur_chunk:
-        if do_fill:
-            lc = len(cur_chunk)
+    src_iter = iter(src)
+    while True:
+        cur_chunk = list(itertools.islice(src_iter, size))
+        if not cur_chunk:
+            break
+        lc = len(cur_chunk)
+        if lc < size and do_fill:
             cur_chunk[lc:] = [fill_val] * (size - lc)
         yield postprocess(cur_chunk)
     return


### PR DESCRIPTION
Hello and thank you for such a nice library.

This PR optimizes `iterutils.chunked_iter` performance (2x on pypy, 5x on cpython).

## Before
```
immerrr@mmrcomp:~/sources/boltons$ time ~/pypy-5.1.1-linux64/bin/pypy bench_chunked_iter.py

real	0m1.862s
user	0m1.824s
sys 	0m0.020s
immerrr@mmrcomp:~/sources/boltons$ time /usr/bin/python2.7 bench_chunked_iter.py

real	0m12.275s
user	0m12.256s
sys 	0m0.004s
immerrr@mmrcomp:~/sources/boltons$ time /usr/bin/python3.5 bench_chunked_iter.py

real	0m17.307s
user	0m17.288s
sys 	0m0.008s
```

## After
```
immerrr@mmrcomp:~/sources/boltons$ time ~/pypy-5.1.1-linux64/bin/pypy bench_chunked_iter.py

real	0m0.926s
user	0m0.868s
sys 	0m0.044s
immerrr@mmrcomp:~/sources/boltons$ time /usr/bin/python2.7 bench_chunked_iter.py

real	0m2.361s
user	0m2.340s
sys 	0m0.008s
immerrr@mmrcomp:~/sources/boltons$ time /usr/bin/python3.5 bench_chunked_iter.py

real	0m3.007s
user	0m2.988s
sys 	0m0.008s
```
With `bench_chunked_iter.py` being:

```python
from boltons.iterutils import chunked_iter
from collections import deque

try:
    xrange
except NameError:
    xrange = range


for i in xrange(100):
    deque(chunked_iter(xrange(1000000), 100), 0)
```