### PR TITLE
Feature: Return namedtuples for get_format_args

### DIFF
--- a/boltons/formatutils.py
+++ b/boltons/formatutils.py
@@ -41,6 +41,7 @@ from __future__ import print_function
 import re
 from string import Formatter
 
+from .namedutils import namedtuple
 
 __all__ = ['DeferredValue', 'get_format_args', 'tokenize_format_str',
            'construct_format_field_str', 'infer_positional_format_args',
@@ -117,6 +118,10 @@ _TYPE_MAP = dict([(x, int) for x in _INTCHARS] +
                  [(x, float) for x in _FLOATCHARS])
 _TYPE_MAP['s'] = str
 
+FormatArgs = namedtuple('FormatArgs', ('positional', 'named'))
+PositionalFormatArg = namedtuple('PositionalFormatArg', ('index', 'type'))
+NamedFormatArg = namedtuple('NamedFormatArg', ('key', 'type'))
+
 
 def get_format_args(fstr):
     """
@@ -142,9 +147,9 @@ def get_format_args(fstr):
             _dedup.add(argname)
             argtype = _TYPE_MAP.get(type_char, str)  # TODO: unicode
             try:
-                fargs.append((int(argname), argtype))
+                fargs.append(PositionalFormatArg(int(argname), argtype))
             except ValueError:
-                fkwargs.append((argname, argtype))
+                fkwargs.append(NamedFormatArg(argname, argtype))
 
     for lit, fname, fspec, conv in formatter.parse(fstr):
         if fname is not None:
@@ -162,7 +167,7 @@ def get_format_args(fstr):
                 # TODO: positional and anon args not allowed here.
                 if subfname is not None:
                     _add_arg(subfname)
-    return fargs, fkwargs
+    return FormatArgs(fargs, fkwargs)
 
 
 def tokenize_format_str(fstr, resolve_pos=True):

--- a/tests/test_formatutils.py
+++ b/tests/test_formatutils.py
@@ -7,7 +7,10 @@ import pytest
 from boltons.formatutils import (get_format_args,
                                  split_format_str,
                                  tokenize_format_str,
-                                 infer_positional_format_args)
+                                 infer_positional_format_args,
+                                 FormatArgs,
+                                 NamedFormatArg,
+                                 PositionalFormatArg)
 
 
 PFAT = namedtuple("PositionalFormatArgTest", "fstr arg_vals res")
@@ -58,7 +61,29 @@ def test_get_fstr_args():
         # example 6 is skipped
 ]))
 def test_get_format_args(sample, expected):
+    """Test `get_format_args` result as tuples."""
     assert get_format_args(sample) == expected
+
+
+@pytest.mark.parametrize(('sample', 'expected'), zip(_TEST_TMPLS, [
+        FormatArgs([], [NamedFormatArg('hello', str)]),
+        FormatArgs([], [NamedFormatArg('hello', str)]),
+        FormatArgs([], [NamedFormatArg('hello', str),
+                        NamedFormatArg('width', str)]),
+        FormatArgs([], [NamedFormatArg('hello', str),
+                        NamedFormatArg('fchar', str),
+                        NamedFormatArg('width', str)]),
+        FormatArgs([PositionalFormatArg(0, str),
+                    PositionalFormatArg(1, int),
+                    PositionalFormatArg(2, float)], []),
+        # example 6 is skipped
+]))
+def test_get_format_args_namedtuples(sample, expected):
+    """Test `get_format_args` result as `namedtuples`."""
+    result = get_format_args(sample)
+    assert result == expected
+    assert result.positional == expected.positional
+    assert result.named == expected.named
 
 
 def test_split_fstr():

--- a/tests/test_formatutils.py
+++ b/tests/test_formatutils.py
@@ -3,6 +3,7 @@
 import re
 from collections import namedtuple
 
+import pytest
 from boltons.formatutils import (get_format_args,
                                  split_format_str,
                                  tokenize_format_str,
@@ -46,6 +47,18 @@ def test_get_fstr_args():
         res = get_format_args(inferred_t)
         results.append(res)
     return results
+
+
+@pytest.mark.parametrize(('sample', 'expected'), zip(_TEST_TMPLS, [
+        ([], [('hello', str)]),
+        ([], [('hello', str)]),
+        ([], [('hello', str), ('width', str)]),
+        ([], [('hello', str), ('fchar', str), ('width', str)]),
+        ([(0, str), (1, int), (2, float)], []),
+        # example 6 is skipped
+]))
+def test_get_format_args(sample, expected):
+    assert get_format_args(sample) == expected
 
 
 def test_split_fstr():


### PR DESCRIPTION
The nested tuple/list structures that are returned by `get_format_args` are fairly cumbersome; returning data `namedtuple` makes accessing the data much cleaner.

I am a bit uncertain about the field names themselves - - I chose 'positional' and 'named' because the documentation for the function describes them that way, but I chose 'key' and 'index' for the component (rather than 'position' and 'name') because those are the standard way to refer to them. It seems a bit inconsistent, however -- perhaps the `FormatArgs` fields should be `indexed` and `keyed`? (or "...s" instead of "...ed"?)