### PR TITLE
Simplified and optimized iterutils.bucketize.

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -13,7 +13,7 @@ following are based on examples in itertools docs.
 import math
 import random
 import itertools
-from collections import Mapping, Sequence, Set, ItemsView
+from collections import Mapping, Sequence, Set, ItemsView, defaultdict
 
 try:
     from typeutils import make_sentinel
@@ -480,18 +480,12 @@ def bucketize(src, key=None):
     item. See :func:`partition` for a version specialized for binary
     use cases.
     """
-    if not is_iterable(src):
-        raise TypeError('expected an iterable')
     if key is None:
         key = bool
-    if not callable(key):
-        raise TypeError('expected callable key function')
-
-    ret = {}
+    ret = defaultdict(list)
     for val in src:
-        keyval = key(val)
-        ret.setdefault(keyval, []).append(val)
-    return ret
+        ret[key(val)].append(val)
+    return dict(ret)
 
 
 def partition(src, key=None):

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -3,6 +3,7 @@ import pytest
 
 from boltons.dictutils import OMD
 from boltons.iterutils import (first,
+                               bucketize,
                                remap,
                                default_enter,
                                default_exit,
@@ -424,3 +425,8 @@ def test_backoff_jitter():
     assert len(nonconst_jittered) == 5
     # no two should be equal realistically
     assert len(set(nonconst_jittered)) == 5
+
+
+def test_bucketize():
+    assert bucketize(range(3)) == {True: [1, 2], False: [0]}
+    assert bucketize('Aba', key=str.lower) == {'a': ['A', 'a'], 'b': ['b']}


### PR DESCRIPTION
Old:

```
In []: timeit iterutils.bucketize(range(10 ** 6), (2).__rmod__)
1 loop, best of 3: 304 ms per loop
```

New:

```
In []: timeit iterutils.bucketize(range(10 ** 6), (2).__rmod__)
1 loop, best of 3: 216 ms per loop
```

And the removed `TypeError` checks will occur anyway.
