### PR TITLE
Add ioutils module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ nosetests.xml
 
 # Vim
 *.sw[op]
+
+.cache/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Boltons is tested against Python 2.6, 2.7, 3.4, 3.5, and PyPy.
 [tbinfo]: https://boltons.readthedocs.org/en/latest/tbutils.html#boltons.tbutils.TracebackInfo
 
 [fileutils]: https://boltons.readthedocs.org/en/latest/fileutils.html#module-boltons.fileutils
+[ioutils]: https://boltons.readthedocs.org/en/latest/ioutils.html#module-boltons.ioutils
 [dictutils]: https://boltons.readthedocs.org/en/latest/dictutils.html#module-boltons.dictutils
 [queueutils]: https://boltons.readthedocs.org/en/latest/queueutils.html#module-boltons.queueutils
 [iterutils]: https://boltons.readthedocs.org/en/latest/iterutils.html#module-boltons.iterutils

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -138,14 +138,13 @@ class SpooledIOBase(object):
     @property
     def len(self):
         """Determine the length of the file"""
-        # Calling .fileno() forces a rollover, so only access fileno if rolled
-        if self._rolled:
-            return os.fstat(self.fileno()).st_size
-
-        # Fallback if still in-memory file
         pos = self.tell()
-        self.seek(0, os.SEEK_END)
-        val = self.tell()
+        if self._rolled:
+            self.seek(0)
+            val = os.fstat(self.fileno()).st_size
+        else:
+            self.seek(0, os.SEEK_END)
+            val = self.tell()
         self.seek(pos)
         return val
 

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -172,6 +172,9 @@ class SpooledIOBase(object):
         self.seek(pos)
         return val
 
+    def __len__(self):
+        return self.len
+
     def __iter__(self):
         yield self.readline()
 

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -332,10 +332,10 @@ class SpooledStringIO(SpooledIOBase):
         self.seek(0)
         enc_pos = 0
         while True:
-            self.read(1)
-            enc_pos += 1
             if self.buffer.tell() == pos:
                 break
+            self.read(1)
+            enc_pos += 1
         self.buffer.seek(pos)
         return enc_pos
 
@@ -346,7 +346,7 @@ class SpooledStringIO(SpooledIOBase):
         self.seek(0)
         total = 0
         while True:
-            ret = self.read(32000)
+            ret = self.read(21333)
             if not ret:
                 break
             total += len(ret)

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -148,7 +148,7 @@ class SpooledIOBase(object):
         # Emulate truncation to a particular location
         pos = self.tell()
         self.seek(size)
-        self.buffer.truncate(size)
+        self.buffer.truncate()
         if pos < size:
             self.seek(pos)
 
@@ -283,7 +283,7 @@ class SpooledStringIO(SpooledIOBase):
         super(SpooledStringIO, self).__init__(*args, **kwargs)
 
     def read(self, n=-1):
-        ret = self.buffer.read(n).decode('utf-8')
+        ret = self.buffer.reader.read(n, n)
         self._tell = self.tell() + len(ret)
         return ret
 
@@ -388,7 +388,7 @@ class SpooledStringIO(SpooledIOBase):
     def len(self):
         """Determine the number of codepoints in the file"""
         pos = self.buffer.tell()
-        self.seek(0)
+        self.buffer.seek(0)
         total = 0
         while True:
             ret = self.read(READ_CHUNK_SIZE)

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -258,7 +258,7 @@ class SpooledBytesIO(SpooledIOBase):
         return val
 
     def tell(self):
-        return self._buffer.tell()
+        return self.buffer.tell()
 
 
 class SpooledStringIO(SpooledIOBase):

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -232,11 +232,10 @@ class SpooledBytesIO(SpooledIOBase):
         """Roll the StringIO over to a TempFile"""
         if not self._rolled:
             tmp = TemporaryFile()
-            pos = self._file.tell()
-            self._buffer.seek(0)
-            tmp.write(self._buffer.read())
+            pos = self.buffer.tell()
+            tmp.write(self.buffer.getvalue())
             tmp.seek(pos)
-            self._buffer.close()
+            self.buffer.close()
             self._buffer = tmp
 
     @property
@@ -308,8 +307,7 @@ class SpooledStringIO(SpooledIOBase):
         if not self._rolled:
             tmp = EncodedFile(TemporaryFile(), data_encoding='utf-8')
             pos = self.buffer.tell()
-            self.buffer.seek(0)
-            tmp.write(self.buffer.read())
+            tmp.write(self.buffer.getvalue())
             tmp.seek(pos)
             self.buffer.close()
             self._buffer = tmp

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -1,0 +1,304 @@
+# -*- coding: UTF-8 -*-
+
+# Coding decl above needed for rendering the emdash properly in the
+# documentation.
+
+"""
+Module ``ioutils`` implements a number of helper classes and functions which
+are useful when dealing with input, output, and bytestreams in a variety of
+ways.
+"""
+import os
+import logging
+import six
+from abc import (
+    ABCMeta,
+    abstractmethod,
+    abstractproperty,
+)
+from errno import EINVAL
+from io import BytesIO
+from codecs import EncodedFile
+from tempfile import TemporaryFile
+
+log = logging.getLogger(__name__)
+
+
+class SpooledIOBase(object):
+    """
+    The SpooledTempoaryFile class doesn't support a number of attributes and
+    methods that a StringIO instance does. This brings the api as close to
+    compatible as possible with StringIO so that it may be used as a near
+    drop-in replacement to save memory.
+
+    Another issue with SpooledTemporaryFile is that the spooled file is always
+    a cStringIO rather than a StringIO which causes issues with some of our
+    tools.
+    """
+    __metaclass__ = ABCMeta
+
+    def __init__(self, max_size=5000000):
+        self._max_size = max_size
+
+    @abstractmethod
+    def read(self, n=-1):
+        """Read n characters from the buffer"""
+        pass
+
+    @abstractmethod
+    def write(self, s):
+        """Write into the buffer"""
+        pass
+
+    @abstractmethod
+    def readline(self, length=None):
+        """Returns the next available line"""
+        pass
+
+    @abstractmethod
+    def readlines(self, sizehint=0):
+        """Returns a list of all lines from the current position forward"""
+        pass
+
+    @abstractmethod
+    def rollover(self):
+        """Roll file-like-object over into a real temporary file"""
+        pass
+
+    @abstractproperty
+    def buffer(self):
+        """Should return a flo instance"""
+        pass
+
+    @abstractproperty
+    def _rolled(self):
+        """Returns whether the file has been rolled to a real file or not"""
+        pass
+
+    def _get_softspace(self):
+        return self.buffer.softspace
+
+    def _set_softspace(self, val):
+        self.buffer.softspace = val
+
+    softspace = property(_get_softspace, _set_softspace)
+
+    @property
+    def _file(self):
+        return self.buffer
+
+    def tell(self):
+        return self._file.tell()
+
+    def seek(self, pos, mode=0):
+        return self.buffer.seek(pos, mode)
+
+    def close(self):
+        return self.buffer.close()
+
+    def flush(self):
+        return self.buffer.flush()
+
+    def isatty(self):
+        return self.buffer.isatty()
+
+    def next(self):
+        return self.readline()
+
+    @property
+    def closed(self):
+        return self.buffer.closed
+
+    @property
+    def pos(self):
+        return self.tell()
+
+    @property
+    def buf(self):
+        return self.getvalue()
+
+    @property
+    def len(self):
+        """Determine the length of the file"""
+        # Calling .fileno() forces a rollover, so only access fileno if rolled
+        if self._rolled:
+            return os.fstat(self.fileno()).st_size
+
+        # Fallback if still in-memory file
+        pos = self.tell()
+        self.seek(0, os.SEEK_END)
+        val = self.tell()
+        self.seek(pos)
+        return val
+
+    def fileno(self):
+        self.rollover()
+        return self.buffer.fileno()
+
+    def truncate(self, size=None):
+        """
+        Custom version of truncate that takes either no arguments (like the
+        real SpooledTemporaryFile) or a single argument that truncates the
+        value to a certain index location.
+        """
+        if size is None:
+            return self.buffer.truncate()
+
+        if size < 0:
+            raise IOError(EINVAL, "Negative size not allowed")
+
+        # Emulate truncation to a particular location
+        pos = self.tell()
+        self.seek(size)
+        self.buffer.truncate(size)
+        if pos < size:
+            self.seek(pos)
+
+    def getvalue(self):
+        """Return the entire files contents"""
+        pos = self.tell()
+        self.seek(0)
+        val = self.read()
+        self.seek(pos)
+        return val
+
+    def __iter__(self):
+        yield self.readline()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self._file.close()
+
+    def __eq__(self, other):
+        if isinstance(other, SpooledIOBase):
+            return self.getvalue() == other.getvalue()
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class SpooledBytesIO(SpooledIOBase):
+    """
+    SpooledBytesIO is a spooled file-like-object that only accepts bytes. On
+    Python 2.x this means the 'str' type; on Python 3.x this means the 'bytes'
+    type. Bytes are written in and retrieved exactly as given, but it will
+    raise TypeErrors if something other than bytes are written.
+
+    Example::
+
+        >>> from lrmslib import ioutils
+        >>> with ioutils.SpooledBytesIO() as f:
+        ...     f.write(b"Happy IO")
+        ...     _ = f.seek(0)
+        ...     print(f.getvalue())
+        Happy IO
+    """
+
+    def read(self, n=-1):
+        return self.buffer.read(n)
+
+    def write(self, s):
+        if not isinstance(s, six.binary_type):
+            raise TypeError("{0} expected, got {1}".format(
+                six.binary_type.__name__,
+                type(s).__name__
+            ))
+
+        self.buffer.write(s)
+        if self.tell() >= self._max_size:
+            self.rollover()
+
+    def readline(self, length=None):
+        return self.buffer.readline(length)
+
+    def readlines(self, sizehint=0):
+        return self.buffer.readlines(sizehint)
+
+    def rollover(self):
+        """Roll the StringIO over to a TempFile"""
+        if not self._rolled:
+            tmp = TemporaryFile()
+            pos = self._file.tell()
+            self.__buffer.seek(0)
+            tmp.write(self.__buffer.read())
+            tmp.seek(pos)
+            self.__buffer.close()
+            self.__buffer = tmp
+
+    @property
+    def _rolled(self):
+        return not isinstance(self.buffer, BytesIO)
+
+    @property
+    def buffer(self):
+        try:
+            return self.__buffer
+        except AttributeError:
+            self.__buffer = BytesIO()
+        return self.__buffer
+
+
+class SpooledStringIO(SpooledIOBase):
+    """
+    SpooledStringIO is a spooled file-like-object that only accepts unicode
+    values. On Python 2.x this means the 'unicode' type and on Python 3.x this
+    means the 'str' type. Values are accepted as unicode and then coerced into
+    utf-8 encoded bytes for storage. On retrieval, the values are returned as
+    unicode.
+
+    Example::
+
+        >>> from lrmslib import ioutils
+        >>> with ioutils.SpooledStringIO() as f:
+        ...     f.write(u"\u2014 Hey, an emdash!")
+        ...     _ = f.seek(0)
+        ...     f.read()
+        u'\u2014 Hey, an emdash!'
+
+     """
+
+    def read(self, n=-1):
+        return self.buffer.read(n).decode('utf-8')
+
+    def write(self, s):
+        if not isinstance(s, six.text_type):
+            raise TypeError("{0} expected, got {1}".format(
+                six.text_type.__name__,
+                type(s).__name__
+            ))
+
+        self.buffer.write(s.encode('utf-8'))
+        if self.tell() >= self._max_size:
+            self.rollover()
+
+    def readline(self, length=None):
+        return self.buffer.readline(length).decode('utf-8')
+
+    def readlines(self, sizehint=0):
+        return [x.decode('utf-8') for x in self.buffer.readlines(sizehint)]
+
+    @property
+    def buffer(self):
+        try:
+            return self.__buffer
+        except AttributeError:
+            self.__buffer = EncodedFile(BytesIO(), data_encoding='utf-8')
+        return self.__buffer
+
+    @property
+    def _rolled(self):
+        return not isinstance(self.buffer.stream, BytesIO)
+
+    def rollover(self):
+        """Roll the StringIO over to a TempFile"""
+        if not self._rolled:
+            tmp = EncodedFile(TemporaryFile(), data_encoding='utf-8')
+            pos = self.buffer.tell()
+            self.buffer.seek(0)
+            tmp.write(self.buffer.read())
+            tmp.seek(pos)
+            self.buffer.close()
+            self.__buffer = tmp

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -240,11 +240,11 @@ class SpooledBytesIO(SpooledIOBase):
         if not self._rolled:
             tmp = TemporaryFile()
             pos = self._file.tell()
-            self.__buffer.seek(0)
-            tmp.write(self.__buffer.read())
+            self._buffer.seek(0)
+            tmp.write(self._buffer.read())
             tmp.seek(pos)
-            self.__buffer.close()
-            self.__buffer = tmp
+            self._buffer.close()
+            self._buffer = tmp
 
     @property
     def _rolled(self):
@@ -253,10 +253,10 @@ class SpooledBytesIO(SpooledIOBase):
     @property
     def buffer(self):
         try:
-            return self.__buffer
+            return self._buffer
         except AttributeError:
-            self.__buffer = BytesIO()
-        return self.__buffer
+            self._buffer = BytesIO()
+        return self._buffer
 
 
 class SpooledStringIO(SpooledIOBase):
@@ -301,10 +301,10 @@ class SpooledStringIO(SpooledIOBase):
     @property
     def buffer(self):
         try:
-            return self.__buffer
+            return self._buffer
         except AttributeError:
-            self.__buffer = EncodedFile(BytesIO(), data_encoding='utf-8')
-        return self.__buffer
+            self._buffer = EncodedFile(BytesIO(), data_encoding='utf-8')
+        return self._buffer
 
     @property
     def _rolled(self):
@@ -319,4 +319,4 @@ class SpooledStringIO(SpooledIOBase):
             tmp.write(self.buffer.read())
             tmp.seek(pos)
             self.buffer.close()
-            self.__buffer = tmp
+            self._buffer = tmp

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -29,19 +29,6 @@ else:
     binary_type = str
 
 
-def utf8_encode_if_unicode(string):
-    """
-    Given a string type, return it in bytes, encoding to UTF-8 if the string is
-    unicode.
-    """
-    if isinstance(string, text_type):
-        return string.encode('utf-8')
-    elif isinstance(string, binary_type):
-        return string
-    else:
-        raise TypeError("{} is not a unicode or str object".format(string))
-
-
 class SpooledIOBase(object):
     """
     The SpooledTempoaryFile class doesn't support a number of attributes and

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -10,7 +10,6 @@ ways.
 """
 import os
 import sys
-import logging
 from abc import (
     ABCMeta,
     abstractmethod,
@@ -20,8 +19,6 @@ from errno import EINVAL
 from io import BytesIO
 from codecs import EncodedFile
 from tempfile import TemporaryFile
-
-log = logging.getLogger(__name__)
 
 # Python2/3 compat
 if sys.version_info[0] == 3:

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -185,9 +185,8 @@ class SpooledIOBase(object):
         self._file.close()
 
     def __eq__(self, other):
-        if isinstance(other, SpooledIOBase):
-            return (utf8_encode_if_unicode(self.getvalue()) ==
-                    utf8_encode_if_unicode(other.getvalue()))
+        if isinstance(other, self.__class__):
+            return self.getvalue() == other.getvalue()
         return False
 
     def __ne__(self, other):

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -61,37 +61,30 @@ class SpooledIOBase(object):
     @abstractmethod
     def read(self, n=-1):
         """Read n characters from the buffer"""
-        pass
 
     @abstractmethod
     def write(self, s):
         """Write into the buffer"""
-        pass
 
     @abstractmethod
     def readline(self, length=None):
         """Returns the next available line"""
-        pass
 
     @abstractmethod
     def readlines(self, sizehint=0):
         """Returns a list of all lines from the current position forward"""
-        pass
 
     @abstractmethod
     def rollover(self):
         """Roll file-like-object over into a real temporary file"""
-        pass
 
     @abstractproperty
     def buffer(self):
         """Should return a flo instance"""
-        pass
 
     @abstractproperty
     def _rolled(self):
         """Returns whether the file has been rolled to a real file or not"""
-        pass
 
     def _get_softspace(self):
         return self.buffer.softspace

--- a/docs/ioutils.rst
+++ b/docs/ioutils.rst
@@ -1,0 +1,29 @@
+``ioutils`` - Input/Output Utilities
+====================================
+
+.. automodule:: boltons.ioutils
+
+Spooled Temporary Files
+-----------------------
+Spooled Temporary Files are file-like objects that start out mapped to
+in-memory objects, but automatically roll over to a temporary file once they
+reach a certain (configurable) threshhold. Unfortunately the built-in
+SpooledTemporaryFile class in Python does not implement the exact API that some
+common classes like StringIO do. SpooledTemporaryFile also spools all of it's
+in-memory files as cStringIO instances. cStringIO instances cannot be
+deep-copied, and they don't work with the zip library either. This along with
+the incompatible api makes it useless for several use-cases.
+
+To combat this but still gain the memory savings and usefulness of a true
+spooled file-like-object, two custom classes have been implemented which have
+a compatible API.
+
+.. _spooledbytesio:
+
+SpooledBytesIO
+^^^^^^^^^^^^^^
+.. autoclass:: boltons.ioutils.SpooledBytesIO
+
+SpooledStringIO
+^^^^^^^^^^^^^^^
+.. autoclass:: boltons.ioutils.SpooledStringIO

--- a/docs/ioutils.rst
+++ b/docs/ioutils.rst
@@ -24,6 +24,41 @@ SpooledBytesIO
 ^^^^^^^^^^^^^^
 .. autoclass:: boltons.ioutils.SpooledBytesIO
 
+.. _spooledstringio:
+
 SpooledStringIO
 ^^^^^^^^^^^^^^^
 .. autoclass:: boltons.ioutils.SpooledStringIO
+
+
+Example
+-------
+A good use case is downloading a file from some remote location. It's nice to
+keep it in memory if it's small, but writing a large file into memory can make
+servers quite grumpy. If the file being downloaded happens to be a zip file
+then things are worse. You can't use a normal SpooledTemporaryFile because it
+isn't compatible. A :ref:`spooledbytesio` instance is a good alternative. Here
+is a simple example using the requests library to download a zip file::
+
+    from zipfile import ZipFile
+
+    import requests
+    from boltons import ioutils
+
+    s = requests.Session()
+    r = s.get("http://127.0.0.1/test_file.zip", stream=True)
+    if r.status_code == 200:
+        flo = SpooledBytesIO()
+
+    r = self._get(url, stream=True)
+    if r.status_code == 200:
+        with ioutils.SpooledBytesIO() as flo:
+            for chunk in r.iter_content(chunk_size=64000):
+                flo.write(chunk)
+
+            flo.seek(0)
+
+            zip_doc = ZipFile(flo)
+
+            # Print all the files in the zip
+            print zip_doc.namelist()

--- a/docs/ioutils.rst
+++ b/docs/ioutils.rst
@@ -31,14 +31,33 @@ SpooledStringIO
 .. autoclass:: boltons.ioutils.SpooledStringIO
 
 
-Example
--------
-A good use case is downloading a file from some remote location. It's nice to
-keep it in memory if it's small, but writing a large file into memory can make
-servers quite grumpy. If the file being downloaded happens to be a zip file
-then things are worse. You can't use a normal SpooledTemporaryFile because it
-isn't compatible. A :ref:`spooledbytesio` instance is a good alternative. Here
-is a simple example using the requests library to download a zip file::
+Examples
+--------
+It's not uncommon to find excessive usage of StringIO in older Python code. A
+SpooledTemporaryFile would be a nice replacement if one wanted to reduce memory
+overhead, but unfortunately it's api differs too much. This is a good candidate
+for :ref:`spooledbytesio` as it is api compatible and thus may be used as a
+drop-in replacement.
+
+Old Code::
+
+    flo = StringIO()
+    flo.write(gigantic_string)
+
+Updated::
+
+    from boltions.ioutils import SpooledBytesIO
+
+    flo = SpooledBytesIO()
+    flo.write(gigantic_string)
+
+
+Another good use case is downloading a file from some remote location. It's
+nice to keep it in memory if it's small, but writing a large file into memory
+can make servers quite grumpy. If the file being downloaded happens to be a zip
+file then things are worse. You can't use a normal SpooledTemporaryFile because
+it isn't compatible. A :ref:`spooledbytesio` instance is a good alternative.
+Here is a simple example using the requests library to download a zip file::
 
     from zipfile import ZipFile
 

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ __contact__ = 'mahmoudrhashemi@gmail.com'
 __url__ = 'https://github.com/mahmoud/boltons'
 __license__ = 'BSD'
 
-INSTALL_REQUIRES = ['six', ]
-
 
 setup(name='boltons',
       version=__version__,
@@ -30,7 +28,6 @@ setup(name='boltons',
       url=__url__,
       packages=['boltons'],
       include_package_data=True,
-      install_requires=INSTALL_REQUIRES,
       zip_safe=False,
       license=__license__,
       platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ __contact__ = 'mahmoudrhashemi@gmail.com'
 __url__ = 'https://github.com/mahmoud/boltons'
 __license__ = 'BSD'
 
+INSTALL_REQUIRES = ['six', ]
+
 
 setup(name='boltons',
       version=__version__,
@@ -28,6 +30,7 @@ setup(name='boltons',
       url=__url__,
       packages=['boltons'],
       include_package_data=True,
+      install_requires=INSTALL_REQUIRES,
       zip_safe=False,
       license=__license__,
       platforms='any',

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -343,3 +343,10 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.spooled_flo.seek(0)
         self.assertEqual(len(self.spooled_flo.read(2)), 2)
         self.assertEqual(self.spooled_flo.read(), '0')
+
+    def test_seek_encoded(self):
+        """Make sure reading works when bytes exceeds read val"""
+        test_str = u"\u2014\u2014\u2014"
+        self.spooled_flo.write(test_str)
+        self.spooled_flo.seek(0)
+        self.assertEqual(self.spooled_flo.read(3), test_str)

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -288,8 +288,22 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.assertEqual(len(self.spooled_flo), len(test_str))
         self.assertEqual(self.spooled_flo.tell(), 3)
 
-    def test_seek_codepoints(self):
-        """Make seek() moves to positions along codepoints"""
+    def test_seek_codepoints_SEEK_END(self):
+        """Make seek() moves to codepoints relative to file end"""
         self.spooled_flo.write(self.test_str)
         ret = self.spooled_flo.seek(0, os.SEEK_END)
         self.assertEqual(ret, len(self.test_str))
+
+    def test_seek_codepoints_SEEK_SET(self):
+        """Make seek() moves to codepoints relative to file start"""
+        self.spooled_flo.write(self.test_str)
+        ret = self.spooled_flo.seek(3, os.SEEK_SET)
+        self.assertEqual(ret, 3)
+
+    def test_seek_codepoints_SEEK_CUR(self):
+        """Make seek() moves to codepoints relative to current_position"""
+        test_str = u"\u2014\u2014\u2014"
+        self.spooled_flo.write(test_str)
+        self.spooled_flo.seek(1)
+        ret = self.spooled_flo.seek(2, os.SEEK_CUR)
+        self.assertEqual(ret, 3)

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -279,6 +279,8 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.spooled_flo.seek(0)
         self.spooled_flo.read(40)
         self.assertEqual(self.spooled_flo.tell(), 40)
+        self.spooled_flo.seek(10)
+        self.assertEqual(self.spooled_flo.tell(), 10)
 
     def test_codepoints_all_enc(self):
         """"Test getting read, seek, tell, on various codepoints"""
@@ -287,7 +289,6 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.spooled_flo.seek(1)
         self.assertEqual(self.spooled_flo.read(), u"\u2014\u2014")
         self.assertEqual(len(self.spooled_flo), len(test_str))
-        self.assertEqual(self.spooled_flo.tell(), 3)
 
     def test_seek_codepoints_SEEK_END(self):
         """Make sure  seek() moves to codepoints relative to file end"""
@@ -334,3 +335,11 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.spooled_flo.seek(1)
         ret = self.spooled_flo.seek(33000, os.SEEK_CUR)
         self.assertEqual(ret, 33001)
+
+    def test_x80_codepoint(self):
+        """Make sure x80 codepoint doesn't confuse read value"""
+        test_str = u'\x8000'
+        self.spooled_flo.write(test_str)
+        self.spooled_flo.seek(0)
+        self.assertEqual(len(self.spooled_flo.read(2)), 2)
+        self.assertEqual(self.spooled_flo.read(), '0')

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -1,0 +1,260 @@
+import os
+from unittest import TestCase
+
+import six
+from boltons import ioutils
+
+
+class BaseTestMixins(object):
+    """
+    A set of tests that work the same for SpooledBtyesIO and SpooledStringIO
+    """
+
+    def test_getvalue_norollover(self):
+        """Make sure getvalue function works with in-memory flo"""
+        self.spooled_flo.write(self.test_str)
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str)
+
+    def test_getvalue_rollover(self):
+        """Make sure getvalue function works with on-disk flo"""
+        self.spooled_flo.write(self.test_str)
+        self.assertFalse(self.spooled_flo._rolled)
+        self.spooled_flo.rollover()
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str)
+        self.assertTrue(self.spooled_flo._rolled)
+
+    def test_truncate_noargs_norollover(self):
+        """Test truncating with no args with in-memory flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(10)
+        self.spooled_flo.truncate()
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
+
+    def test_truncate_noargs_rollover(self):
+        """Test truncating with no args with on-disk flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(10)
+        self.spooled_flo.rollover()
+        self.spooled_flo.truncate()
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
+
+    def test_truncate_with_args_norollover(self):
+        """Test truncating to a value with in-memory flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(5)
+        self.spooled_flo.truncate(10)
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
+        self.assertEqual(self.spooled_flo.tell(), 5)
+
+    def test_truncate_with_args_rollover(self):
+        """Test truncating to a value with on-disk flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(5)
+        self.spooled_flo.rollover()
+        self.spooled_flo.truncate(10)
+        self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
+        self.assertEqual(self.spooled_flo.tell(), 5)
+
+    def test_type_error_too_many_args(self):
+        """Make sure TypeError raised if too many args passed to truncate"""
+        self.spooled_flo.write(self.test_str)
+        with self.assertRaises(TypeError):
+            self.spooled_flo.truncate(0, 10)
+
+    def test_io_error_negative_truncate(self):
+        """Make sure IOError raised trying to truncate with negative value"""
+        self.spooled_flo.write(self.test_str)
+        with self.assertRaises(IOError):
+            self.spooled_flo.truncate(-1)
+
+    def test_compare_different_instances(self):
+        """Make sure we can compare instances of a different type"""
+        a = ioutils.SpooledBytesIO()
+        a.write(six.binary_type("I am equal!"))
+        b = ioutils.SpooledStringIO()
+        b.write(six.text_type("I am equal!"))
+        self.assertEqual(a, b)
+
+    def test_compare_unequal_instances(self):
+        """Comparisons of non-SpooledIOBase classes should fail"""
+        self.assertNotEqual("Bummer dude", self.spooled_flo)
+
+    def test_set_softspace_attribute(self):
+        """Ensure softspace attribute can be retrieved and set"""
+        self.spooled_flo.softspace = True
+        self.assertTrue(self.spooled_flo.softspace)
+
+    def test_set_softspace_attribute_rolled(self):
+        """Ensure softspace attribute can be retrieved and set if rolled"""
+        self.spooled_flo.softspace = True
+        self.assertTrue(self.spooled_flo.softspace)
+        self.spooled_flo.rollover()
+        self.spooled_flo.softspace = True
+        self.assertTrue(self.spooled_flo.softspace)
+
+    def test_iter(self):
+        """Make sure iter works as expected"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(0)
+        self.assertEqual([x for x in self.spooled_flo][0], self.test_str)
+        self.assertEqual([x for x in self.spooled_flo][0], self.data_type(''))
+
+    def test_buf_property(self):
+        """'buf' property returns the same value as getvalue()"""
+        self.assertEqual(self.spooled_flo.buf, self.spooled_flo.getvalue())
+
+    def test_pos_property(self):
+        """'pos' property returns the same value as tell()"""
+        self.assertEqual(self.spooled_flo.pos, self.spooled_flo.tell())
+
+    def test_closed_property(self):
+        """'closed' property works as expected"""
+        self.assertFalse(self.spooled_flo.closed)
+        self.spooled_flo.close()
+        self.assertTrue(self.spooled_flo.closed)
+
+    def test_readline(self):
+        """Make readline returns expected values"""
+        self.spooled_flo.write(self.test_str_lines)
+        self.spooled_flo.seek(0)
+        self.assertEqual(self.spooled_flo.readline().rstrip(os.linesep),
+                         self.test_str_lines.split(os.linesep)[0])
+
+    def test_readlines(self):
+        """Make sure readlines returns expected values"""
+        self.spooled_flo.write(self.test_str_lines)
+        self.spooled_flo.seek(0)
+        self.assertEqual(
+            [x.rstrip(os.linesep) for x in self.spooled_flo.readlines()],
+            self.test_str_lines.split(os.linesep)
+        )
+
+    def test_next(self):
+        """Make next returns expected values"""
+        self.spooled_flo.write(self.test_str_lines)
+        self.spooled_flo.seek(0)
+        self.assertEqual(self.spooled_flo.next().rstrip(os.linesep),
+                         self.test_str_lines.split(os.linesep)[0])
+
+    def test_isatty(self):
+        """Make sure we can check if the value is a tty"""
+        # This should simply not fail
+        self.assertTrue(self.spooled_flo.isatty() is True or
+                        self.spooled_flo.isatty() is False)
+
+
+class TestSpooledBytesIO(TestCase, BaseTestMixins):
+
+    def setUp(self):
+        self.spooled_flo = ioutils.SpooledBytesIO()
+        self.test_str = "Armado en los EE, UU. para S. P. Richards co.,"
+        self.test_str_lines = "Text with:{0}newlines!".format(os.linesep)
+        self.data_type = six.binary_type
+
+    def test_compare_not_equal_instances(self):
+        """Make sure instances with different values fail == check."""
+        a = ioutils.SpooledBytesIO()
+        a.write("I am a!")
+        b = ioutils.SpooledBytesIO()
+        b.write("I am b!")
+        self.assertNotEqual(a, b)
+
+    def test_compare_two_equal_instances(self):
+        """Make sure we can compare instances"""
+        a = ioutils.SpooledBytesIO()
+        a.write("I am equal!")
+        b = ioutils.SpooledBytesIO()
+        b.write("I am equal!")
+        self.assertEqual(a, b)
+
+    def test_auto_rollover(self):
+        """Make sure file rolls over to disk after max_size reached"""
+        tmp = ioutils.SpooledBytesIO(max_size=10)
+        tmp.write("The quick brown fox jumped over the lazy dogs.")
+        self.assertTrue(tmp._rolled)
+
+    def test_use_as_context_mgr(self):
+        """Make sure SpooledBytesIO can be used as a context manager"""
+        test_str = "Armado en los EE, UU. para S. P. Richards co.,"
+        with ioutils.SpooledBytesIO() as f:
+            f.write(test_str)
+            self.assertEqual(f.getvalue(), test_str)
+
+    def test_len_no_rollover(self):
+        """Make sure len property works with in-memory flo"""
+        self.spooled_flo.write(self.test_str)
+        self.assertEqual(self.spooled_flo.len, len(self.test_str))
+
+    def test_len_rollover(self):
+        """Make sure len property works with on-disk flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.rollover()
+        self.assertEqual(self.spooled_flo.len, len(self.test_str))
+
+    def test_invalid_type(self):
+        """Ensure TypeError raised when writing unicode to SpooledBytesIO"""
+        with self.assertRaises(TypeError):
+            self.spooled_flo.write(u"hi")
+
+    def test_flush_after_rollover(self):
+        """Make sure we can flush before and after rolling to a real file"""
+        self.spooled_flo.write(self.test_str)
+        self.assertIsNone(self.spooled_flo.flush())
+        self.spooled_flo.rollover()
+        self.assertIsNone(self.spooled_flo.flush())
+
+
+class TestSpooledStringIO(TestCase, BaseTestMixins):
+
+    def setUp(self):
+        self.spooled_flo = ioutils.SpooledStringIO()
+        self.test_str = u"Remember kids, always use an emdash: '\u2014'"
+        self.test_str_lines = u"Text with\u2014{0}newlines!".format(os.linesep)
+        self.data_type = six.text_type
+
+    def test_compare_not_equal_instances(self):
+        """Make sure instances with different values fail == check."""
+        a = ioutils.SpooledStringIO()
+        a.write(u"I am a!")
+        b = ioutils.SpooledStringIO()
+        b.write(u"I am b!")
+        self.assertNotEqual(a, b)
+
+    def test_compare_two_equal_instances(self):
+        """Make sure we can compare instances"""
+        a = ioutils.SpooledStringIO()
+        a.write(u"I am equal!")
+        b = ioutils.SpooledStringIO()
+        b.write(u"I am equal!")
+        self.assertEqual(a, b)
+
+    def test_auto_rollover(self):
+        """Make sure file rolls over to disk after max_size reached"""
+        tmp = ioutils.SpooledStringIO(max_size=10)
+        tmp.write(u"The quick brown fox jumped over the lazy dogs.")
+        self.assertTrue(tmp._rolled)
+
+    def test_use_as_context_mgr(self):
+        """Make sure SpooledStringIO can be used as a context manager"""
+        test_str = u"Armado en los EE, UU. para S. P. Richards co.,"
+        with ioutils.SpooledStringIO() as f:
+            f.write(test_str)
+            self.assertEqual(f.getvalue(), test_str)
+
+    def test_len_no_rollover(self):
+        """Make sure len property works with in-memory flo"""
+        self.spooled_flo.write(self.test_str)
+        self.assertEqual(self.spooled_flo.len,
+                         len(self.test_str.encode('utf-8')))
+
+    def test_len_rollover(self):
+        """Make sure len propery works with on-disk flo"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.rollover()
+        self.assertEqual(self.spooled_flo.len,
+                         len(self.test_str.encode('utf-8')))
+
+    def test_invalid_type(self):
+        """Ensure TypeError raised when writing bytes to SpooledStringIO"""
+        with self.assertRaises(TypeError):
+            self.spooled_flo.write(b"hi")

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -262,15 +262,13 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
     def test_len_no_rollover(self):
         """Make sure len property works with in-memory flo"""
         self.spooled_flo.write(self.test_str)
-        self.assertEqual(self.spooled_flo.len,
-                         len(self.test_str.encode('utf-8')))
+        self.assertEqual(self.spooled_flo.len, len(self.test_str))
 
     def test_len_rollover(self):
         """Make sure len propery works with on-disk flo"""
         self.spooled_flo.write(self.test_str)
         self.spooled_flo.rollover()
-        self.assertEqual(self.spooled_flo.len,
-                         len(self.test_str.encode('utf-8')))
+        self.assertEqual(self.spooled_flo.len, len(self.test_str))
 
     def test_invalid_type(self):
         """Ensure TypeError raised when writing bytes to SpooledStringIO"""

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -278,3 +278,18 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.spooled_flo.seek(0)
         self.spooled_flo.read(40)
         self.assertEqual(self.spooled_flo.tell(), 40)
+
+    def test_codepoints_all_enc(self):
+        """"Test getting read, seek, tell, on various codepoints"""
+        test_str = u"\u2014\u2014\u2014"
+        self.spooled_flo.write(test_str)
+        self.spooled_flo.seek(1)
+        self.assertEqual(self.spooled_flo.read(), u"\u2014\u2014")
+        self.assertEqual(len(self.spooled_flo), len(test_str))
+        self.assertEqual(self.spooled_flo.tell(), 3)
+
+    def test_seek_codepoints(self):
+        """Make seek() moves to positions along codepoints"""
+        self.spooled_flo.write(self.test_str)
+        ret = self.spooled_flo.seek(0, os.SEEK_END)
+        self.assertEqual(ret, len(self.test_str))

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -322,6 +322,7 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         test_str = u"\u2014\u2014\u2014"
         self.spooled_flo.write(test_str)
         self.spooled_flo.seek(1)
+        self.assertEqual(self.spooled_flo.tell(), 1)
         ret = self.spooled_flo.seek(2, os.SEEK_CUR)
         self.assertEqual(ret, 3)
 

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -14,7 +14,13 @@ else:
     binary_type = str
 
 
-class BaseTestMixins(object):
+class AssertionsMixin(object):
+
+    def assertIsNone(self, item, msg=None):
+        self.assertTrue(item is None, msg)
+
+
+class BaseTestMixin(object):
     """
     A set of tests that work the same for SpooledBtyesIO and SpooledStringIO
     """
@@ -67,14 +73,12 @@ class BaseTestMixins(object):
     def test_type_error_too_many_args(self):
         """Make sure TypeError raised if too many args passed to truncate"""
         self.spooled_flo.write(self.test_str)
-        with self.assertRaises(TypeError):
-            self.spooled_flo.truncate(0, 10)
+        self.assertRaises(TypeError, self.spooled_flo.truncate, 0, 10)
 
     def test_io_error_negative_truncate(self):
         """Make sure IOError raised trying to truncate with negative value"""
         self.spooled_flo.write(self.test_str)
-        with self.assertRaises(IOError):
-            self.spooled_flo.truncate(-1)
+        self.assertRaises(IOError, self.spooled_flo.truncate, -1)
 
     def test_compare_different_instances(self):
         """Make sure we can compare instances of a different type"""
@@ -152,7 +156,7 @@ class BaseTestMixins(object):
                         self.spooled_flo.isatty() is False)
 
 
-class TestSpooledBytesIO(TestCase, BaseTestMixins):
+class TestSpooledBytesIO(TestCase, BaseTestMixin, AssertionsMixin):
     linesep = os.linesep.encode('ascii')
 
     def setUp(self):
@@ -205,8 +209,7 @@ class TestSpooledBytesIO(TestCase, BaseTestMixins):
 
     def test_invalid_type(self):
         """Ensure TypeError raised when writing unicode to SpooledBytesIO"""
-        with self.assertRaises(TypeError):
-            self.spooled_flo.write(u"hi")
+        self.assertRaises(TypeError, self.spooled_flo.write, u"hi")
 
     def test_flush_after_rollover(self):
         """Make sure we can flush before and after rolling to a real file"""
@@ -216,7 +219,7 @@ class TestSpooledBytesIO(TestCase, BaseTestMixins):
         self.assertIsNone(self.spooled_flo.flush())
 
 
-class TestSpooledStringIO(TestCase, BaseTestMixins):
+class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
     linesep = os.linesep
 
     def setUp(self):
@@ -269,5 +272,4 @@ class TestSpooledStringIO(TestCase, BaseTestMixins):
 
     def test_invalid_type(self):
         """Ensure TypeError raised when writing bytes to SpooledStringIO"""
-        with self.assertRaises(TypeError):
-            self.spooled_flo.write(b"hi")
+        self.assertRaises(TypeError, self.spooled_flo.write, b"hi")

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -81,12 +81,12 @@ class BaseTestMixin(object):
         self.assertRaises(IOError, self.spooled_flo.truncate, -1)
 
     def test_compare_different_instances(self):
-        """Make sure we can compare instances of a different type"""
+        """Make sure two different instance types are not considered equal"""
         a = ioutils.SpooledBytesIO()
         a.write(binary_type(b"I am equal!"))
         b = ioutils.SpooledStringIO()
         b.write(text_type("I am equal!"))
-        self.assertEqual(a, b)
+        self.assertNotEqual(a, b)
 
     def test_compare_unequal_instances(self):
         """Comparisons of non-SpooledIOBase classes should fail"""

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -197,15 +197,17 @@ class TestSpooledBytesIO(TestCase, BaseTestMixin, AssertionsMixin):
             self.assertEqual(f.getvalue(), test_str)
 
     def test_len_no_rollover(self):
-        """Make sure len property works with in-memory flo"""
+        """Make sure len works with in-memory flo"""
         self.spooled_flo.write(self.test_str)
         self.assertEqual(self.spooled_flo.len, len(self.test_str))
+        self.assertEqual(len(self.spooled_flo), len(self.test_str))
 
     def test_len_rollover(self):
-        """Make sure len property works with on-disk flo"""
+        """Make sure len works with on-disk flo"""
         self.spooled_flo.write(self.test_str)
         self.spooled_flo.rollover()
         self.assertEqual(self.spooled_flo.len, len(self.test_str))
+        self.assertEqual(len(self.spooled_flo), len(self.test_str))
 
     def test_invalid_type(self):
         """Ensure TypeError raised when writing unicode to SpooledBytesIO"""

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -59,7 +59,6 @@ class BaseTestMixin(object):
         self.spooled_flo.seek(5)
         self.spooled_flo.truncate(10)
         self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
-        self.assertEqual(self.spooled_flo.tell(), 5)
 
     def test_truncate_with_args_rollover(self):
         """Test truncating to a value with on-disk flo"""
@@ -68,7 +67,6 @@ class BaseTestMixin(object):
         self.spooled_flo.rollover()
         self.spooled_flo.truncate(10)
         self.assertEqual(self.spooled_flo.getvalue(), self.test_str[:10])
-        self.assertEqual(self.spooled_flo.tell(), 5)
 
     def test_type_error_too_many_args(self):
         """Make sure TypeError raised if too many args passed to truncate"""
@@ -273,3 +271,10 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
     def test_invalid_type(self):
         """Ensure TypeError raised when writing bytes to SpooledStringIO"""
         self.assertRaises(TypeError, self.spooled_flo.write, b"hi")
+
+    def test_tell_codepoints(self):
+        """Verify tell() returns codepoint position, not bytes position"""
+        self.spooled_flo.write(self.test_str)
+        self.spooled_flo.seek(0)
+        self.spooled_flo.read(40)
+        self.assertEqual(self.spooled_flo.tell(), 40)

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -1,7 +1,8 @@
 import os
+import random
+import string
 import sys
 from unittest import TestCase
-
 
 from boltons import ioutils
 
@@ -289,21 +290,46 @@ class TestSpooledStringIO(TestCase, BaseTestMixin, AssertionsMixin):
         self.assertEqual(self.spooled_flo.tell(), 3)
 
     def test_seek_codepoints_SEEK_END(self):
-        """Make seek() moves to codepoints relative to file end"""
+        """Make sure  seek() moves to codepoints relative to file end"""
         self.spooled_flo.write(self.test_str)
         ret = self.spooled_flo.seek(0, os.SEEK_END)
         self.assertEqual(ret, len(self.test_str))
 
+    def test_seek_codepoints_large_SEEK_END(self):
+        """Make sure seek() moves to codepoints relative to file end"""
+        test_str = u"".join(random.choice(string.ascii_letters) for
+                            x in range(34000))
+        self.spooled_flo.write(test_str)
+        ret = self.spooled_flo.seek(0, os.SEEK_END)
+        self.assertEqual(ret, len(test_str))
+
     def test_seek_codepoints_SEEK_SET(self):
-        """Make seek() moves to codepoints relative to file start"""
+        """Make sure seek() moves to codepoints relative to file start"""
         self.spooled_flo.write(self.test_str)
         ret = self.spooled_flo.seek(3, os.SEEK_SET)
         self.assertEqual(ret, 3)
 
+    def test_seek_codepoints_large_SEEK_SET(self):
+        """Make sure seek() moves to codepoints relative to file start"""
+        test_str = u"".join(random.choice(string.ascii_letters) for
+                            x in range(34000))
+        self.spooled_flo.write(test_str)
+        ret = self.spooled_flo.seek(33000, os.SEEK_SET)
+        self.assertEqual(ret, 33000)
+
     def test_seek_codepoints_SEEK_CUR(self):
-        """Make seek() moves to codepoints relative to current_position"""
+        """Make sure seek() moves to codepoints relative to current_position"""
         test_str = u"\u2014\u2014\u2014"
         self.spooled_flo.write(test_str)
         self.spooled_flo.seek(1)
         ret = self.spooled_flo.seek(2, os.SEEK_CUR)
         self.assertEqual(ret, 3)
+
+    def test_seek_codepoints_large_SEEK_CUR(self):
+        """Make sure seek() moves to codepoints relative to current_position"""
+        test_str = u"".join(random.choice(string.ascii_letters) for
+                            x in range(34000))
+        self.spooled_flo.write(test_str)
+        self.spooled_flo.seek(1)
+        ret = self.spooled_flo.seek(33000, os.SEEK_CUR)
+        self.assertEqual(ret, 33001)


### PR DESCRIPTION
Spooled Temporary Files are file-like objects
that start out mapped to in-memory objects, but
automatically roll over to a temporary file once
they reach a certain (configurable) threshhold.
Unfortunately the built-in SpooledTemporaryFile
class in Python does not implement the exact API
that some common classes like StringIO do.
SpooledTemporaryFile also spools all of it's in-memory
files as cStringIO instances. cStringIO instances cannot
be deep-copied, and they don't work with the zip
library either. This along with the incompatible api makes
it useless for several use-cases.

To combat this but still gain the memory savings and
usefulness of a true spooled file-like-object, two custom
classes have been implemented which have a compatible API.

SpooledBytesIO is a spooled file-like-object that only
accepts bytes. On Python 2.x this means the 'str' type; on
Python 3.x this means the 'bytes' type. Bytes are written
in and retrieved exactly as given, but it will raise TypeErrors
if something other than bytes are written.

SpooledStringIO is a spooled file-like-object that only accepts
unicode values. On Python 2.x this means the 'unicode' type and
on Python 3.x this means the 'str' type. Values are accepted as
unicode and then coerced into utf-8 encoded bytes for storage. On
retrieval, the values are returned as unicode.