### PR TITLE
Rollover to file before writing overflow value

### DIFF
--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -208,9 +208,9 @@ class SpooledBytesIO(SpooledIOBase):
                 type(s).__name__
             ))
 
-        self.buffer.write(s)
-        if self.tell() >= self._max_size:
+        if self.tell() + len(s) >= self._max_size:
             self.rollover()
+        self.buffer.write(s)
 
     def seek(self, pos, mode=0):
         return self.buffer.seek(pos, mode)


### PR DESCRIPTION
If the write operation is going to push a
SpooledBytesIO instance beyond it's max size, dispatch
a rollover to disk before performing the write. This
prevents duplicating a giant slug of data into memory
if a write of lots of data is attempted. This optimization
was made already for the SpooledStringIO write method
but was omitted by mistake from the SpooledBytesIO
implementation.