### PR TITLE
Add FrozenDict type to dictutils

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -720,6 +720,10 @@ class FrozenDictBase(tuple):
                 break
             idx += 1
 
+    def items(self):
+        """Returns a list of tuples of data"""
+        return [(x, self[x]) for x in self]
+
     def iteritems(self):
         """Iterates, returning key, value pairs as a tuple"""
         idx = 0
@@ -745,6 +749,11 @@ class FrozenDictBase(tuple):
     def __contains__(self, value):
         return hasattr(self, str(value.__hash__()))
 
+    def __reduce__(self):
+        state = {}
+        for k, v in self.iteritems():
+            state[k] = v
+        return (FrozenDict, (state, ))
 
 def FrozenDict(dict_map):
     """A FrozenDict is a dictionary whose values are set during instance

--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -737,7 +737,10 @@ class FrozenDictBase(tuple):
             return default
 
     def keys(self):
-        return [x[0] for x in self]
+        return [x for x in self]
+
+    def values(self):
+        return [x[1] for x in tuple.__iter__(self)]
 
     def __contains__(self, value):
         return hasattr(self, str(value.__hash__()))

--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -724,7 +724,7 @@ class FrozenDict(Mapping):
 
     def __init__(self, **kwargs):
         self._storage = namedtuple("FrozenDictStore",
-                                   " ".join(sorted(kwargs.keys())))(**kwargs)
+                                   " ".join(kwargs.keys()))(**kwargs)
 
     def __iter__(self):
         return iter(self._storage._fields)

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -275,6 +275,13 @@ class TestFrozenDict(TestCase):
         self.assertEqual(self.frozen_dict["b"], 2)
         self.assertEqual(self.frozen_dict["c"], 3)
 
+    def test_values(self):
+        """Verify .values() implementation"""
+        self.assertTrue(1 in self.frozen_dict.values())
+        self.assertTrue(2 in self.frozen_dict.values())
+        self.assertTrue(3 in self.frozen_dict.values())
+        self.assertEqual(len(self.frozen_dict.values()), 3)
+
     def test_keyerror(self):
         """Verify dict KeyError raised when accessing invalid keys"""
         try:

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pickle
 from unittest import TestCase
 from boltons.dictutils import OMD, FrozenDict
 
@@ -282,6 +283,12 @@ class TestFrozenDict(TestCase):
         self.assertTrue(3 in self.frozen_dict.values())
         self.assertEqual(len(self.frozen_dict.values()), 3)
 
+    def test_items(self):
+        """Verify .items() implementation returns list of tuples"""
+        self.assertTrue(isinstance(self.frozen_dict.items(), list))
+        for val in self.frozen_dict.items():
+            self.assertTrue(isinstance(val, tuple))
+
     def test_keyerror(self):
         """Verify dict KeyError raised when accessing invalid keys"""
         try:
@@ -319,3 +326,9 @@ class TestFrozenDict(TestCase):
     def test_calculate_len(self):
         """Ensure len() is calculated on key total"""
         self.assertEqual(len(self.frozen_dict), 3)
+
+    def test_pickle_dict(self):
+        """Make sure a frozendict is possible to pickle"""
+        pickle_str = pickle.dumps(self.frozen_dict)
+        new_instance = pickle.loads(pickle_str)
+        self.assertEqual(self.frozen_dict, new_instance)

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -261,7 +261,7 @@ def test_setdefault():
 class TestFrozenDict(TestCase):
 
     def setUp(self):
-        self.frozen_dict = FrozenDict(a=1, b=2, c=3)
+        self.frozen_dict = FrozenDict({"a": 1, "b": 2, "c": 3})
 
     def test_get(self):
         """Verify .get works with FrozenDict"""

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+from unittest import TestCase
+from boltons.dictutils import OMD, FrozenDict
 
-from boltons.dictutils import OMD
 
 _ITEMSETS = [[],
              [('a', 1), ('b', 2), ('c', 3)],
@@ -255,3 +256,59 @@ def test_setdefault():
     y = omd.setdefault('2')
     assert y is None
     assert omd.setdefault('1', None) is empty_list
+
+
+class TestFrozenDict(TestCase):
+
+    def setUp(self):
+        self.frozen_dict = FrozenDict(a=1, b=2, c=3)
+
+    def test_get(self):
+        """Verify .get works with FrozenDict"""
+        self.assertEqual(self.frozen_dict.get("a"), 1)
+        self.assertEqual(self.frozen_dict.get("b"), 2)
+        self.assertEqual(self.frozen_dict.get("c"), 3)
+
+    def test_key(self):
+        """Verify dict key access works with FrozenDict"""
+        self.assertEqual(self.frozen_dict["a"], 1)
+        self.assertEqual(self.frozen_dict["b"], 2)
+        self.assertEqual(self.frozen_dict["c"], 3)
+
+    def test_keyerror(self):
+        """Verify dict KeyError raised when accessing invalid keys"""
+        try:
+            self.frozen_dict['badkey']
+        except KeyError:
+            pass
+        else:
+            raise AssertionError("FrozenDict failed to raise KeyError")
+
+    def test_update_fails(self):
+        """Make sure updating existing value raises a TypeError"""
+        try:
+            self.frozen_dict['c'] = 4
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("FrozenDict failed to raise TypeError on set")
+
+    def test_assignment_failure(self):
+        """Make sure a TypeError is raised on assignment attempts"""
+        try:
+            self.frozen_dict['d'] = 4
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("FrozenDict failed to raise TypeError on set")
+
+    def test_hash_frozendict(self):
+        """Make sure a FrozenDict can be used as a dict key"""
+        try:
+            {self.frozen_dict: "hashable"}
+        except TypeError:
+            raise AssertionError("FrozenDict is not hashable")
+
+    def test_calculate_len(self):
+        """Ensure len() is calculated on key total"""
+        self.assertEqual(len(self.frozen_dict), 3)


### PR DESCRIPTION
This is another tool I have built a number of times in various permutations; 
I don't know if it's all that interesting but I've found it quite useful in a number
of situations including immutable constant maps without heinous amounts of
namedtuple boilerplate, and some cases with threading. 

A FrozenDict is a dictionary whose values are
set during instance creation and are fixed from
that point on. Setting and altering values is
not allowed. This can be useful in a number of
scenarios, including setting up mapping constants
without worrying that the values will get mutated
by a misbehaving function.

There are a lot of online recipes for creating a
FrozenDict class, but most still rely on a real
dictionary under the hood for storage. They also
tend to be extra weighty because they have an
underlying object dict.

One common solution is to use a named tuple, but this
requires setting up boilerplate for every type or
relying on factory functions. The FrozenDict utilizes
a named tuple for storage and then is further made
lighter by utilizing __slots__ to eliminate the
underlying object dict.