### PR TITLE
Preserve original docstring in cachedproperty

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -648,15 +648,14 @@ class cachedproperty(object):
     allows the cache to be cleared with :func:`delattr`, or through
     manipulating the object's ``__dict__``.
     """
-
     def __init__(self, func):
+        self.__doc__ = getattr(func, '__doc__')
         self.func = func
 
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
-        value = self.func(obj)
-        setattr(obj, self.func.__name__, value)
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
 
     def __repr__(self):

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -270,6 +270,7 @@ def test_cachedproperty():
 
         @cachedproperty
         def useful_attr(self):
+            """Useful DocString"""
             return self.expensive_func()
 
     prop = Proper()
@@ -279,6 +280,9 @@ def test_cachedproperty():
     assert prop.expensive_func.call_count == 1
     assert prop.useful_attr == 1
     assert prop.expensive_func.call_count == 1
+
+    # Make sure original DocString is accessible
+    assert Proper.useful_attr.__doc__ == "Useful DocString"
 
     prop.useful_attr += 1  # would not be possible with normal properties
     assert prop.useful_attr == 2


### PR DESCRIPTION
This fixes Issue #109

Set the __doc__ attribute on the original
docstring so that the docstring is preserved
and visible to tooling like sphinx and epydoc.

Slightly simply __get__ and remove a line of code