### PR TITLE
Test boltons against all Python-related Travis CI targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
 language: python
 sudo: false
 cache: pip
+
+# Python targets, as defined by https://github.com/travis-ci/travis-build/blob
+# /master/spec/build/script/python_spec.rb and https://github.com/travis-ci
+# /travis-build/blob/master/lib/travis/build/script/python.rb
 python:
-  - "2.6"
+  # Standard release https://docs.travis-ci.com/user/languages
+  # /python#choosing-python-versions-to-test-against
   - "2.7"
+  - "3.3"
   - "3.4"
   - "3.5"
-  - "pypy"
+  - "3.6"
+  - "3.7-dev"  # a.k.a "nightly"
+
+  # PyPy2.7: https://doc.pypy.org/en/latest
+  # /index-of-release-notes.html#cpython-2-7-compatible-versions
+  - pypy  # PyPy2.7 2.5.0
+  - pypy-5.1
+  - pypy-5.3
+  - pypy-5.4
+
+  # PyPy3.3: https://doc.pypy.org/en/latest
+  # /index-of-release-notes.html#cpython-3-3-compatible-versions
+  - pypy3.3-5.2-alpha1
 
 install: "pip install -r requirements-test.txt"
 script: "py.test --doctest-modules boltons tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache: pip
 python:
   # Standard release https://docs.travis-ci.com/user/languages
   # /python#choosing-python-versions-to-test-against
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,24 @@ setup(name='boltons',
       license=__license__,
       platforms='any',
       classifiers=[
+          # See: https://pypi.python.org/pypi?:action=list_classifiers
           'Topic :: Utilities',
           'Intended Audience :: Developers',
+          'License :: OSI Approved :: BSD License',
           'Topic :: Software Development :: Libraries',
           'Development Status :: 5 - Production/Stable',
+          'Operating System :: OS Independent',
+          # List of python versions and their support status:
+          # https://en.wikipedia.org/wiki/CPython#Version_history
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy', ]
       )
 


### PR DESCRIPTION
Changelog:
* Try building boltons against all possible Python targets.
* Document Travis CI Python targets.
* Update list of trove classifiers.
* Document trove classifiers.

This is mainly a test to see if boltons stand up against all Python targets I found on Travis. The reason I started this is I stumble upon an [issue with Python 3.3 and `remap`](https://travis-ci.org/kdeldycke/meta-package-manager/jobs/192211967#L576) utility.

I'll be happy to close or amend this PR depending on feedbacks.