### PR TITLE
Make Callpoint.to_dict result JSON serializable

### DIFF
--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -79,9 +79,11 @@ class Callpoint(object):
         ret = {}
         for slot in self.__slots__:
             try:
-                ret[slot] = getattr(self, slot)
+                val = getattr(self, slot)
             except AttributeError:
                 pass
+            else:
+                ret[slot] = str(val) if isinstance(val, _DeferredLine) else val
         return ret
 
     @classmethod

--- a/tests/test_tbutils.py
+++ b/tests/test_tbutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import json
 import sys
 
 try:
@@ -76,6 +76,11 @@ def test_contextual():
     assert line.startswith(' ')
     assert line.strip() == 'return func3()'
     assert 'func2' in repr(callpoint)
+
+    try:
+        json.dumps(callpoint.to_dict())
+    except TypeError:
+        raise AssertionError("to_dict result is not JSON serializable")
 
     def func_a():
         a = 1


### PR DESCRIPTION
This is one possible solution to the issue outlined in https://github.com/mahmoud/boltons/issues/112
I have another pull request with a different solution.

Converts all instances of _DeferredLine into string
objects when returning the dictionary. This has the
effect of making the resulting dictionary instance
JSON serializable.