### PR TITLE
Use 'hex_code' instead of alias 'hex' (python3.3 fix)

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -994,7 +994,7 @@ class GUIDerator(object):
                               socket.gethostname() or b'<nohostname>',
                               str(time.time()),
                               codecs.encode(os.urandom(6),
-                                            'hex').decode('ascii')])
+                                            'hex_codec').decode('ascii')])
         # that codecs trick is the best/only way to get a bytes to
         # hexbytes in py2/3
         return


### PR DESCRIPTION
Fixes an incompatibility with Python3.3 that turned up in https://github.com/mahmoud/boltons/pull/111

The reseed function in iterutils GUIDerator uses codecs
to get hexbytes in a python2/3 compatible way. It was
relying on the 'hex' codec which an alias for 'hex_codec'.
The 'hex' to 'hex_codec' alias is missing for some reason
in Python3.3.

This patch uses the direct name of the codec instead of the
alias so that GUIDerator will work on all versions of Python,
regardless of the presence of the 'hex' alias.