### PR TITLE
Change Sentinel __nonzero__ to __len__ for Python3 Compatibility

### DIFF
--- a/boltons/typeutils.py
+++ b/boltons/typeutils.py
@@ -53,8 +53,8 @@ def make_sentinel(name='_MISSING', var_name=None):
             def __reduce__(self):
                 return self.var_name
 
-        def __nonzero__(self):
-            return False
+        def __len__(self):
+            return 0
     return Sentinel()
 
 


### PR DESCRIPTION
This fixes a Python3 compatibility bug in the `make_sentinel` function. Python3 uses `__bool__` instead of Python2's `__nonzero__`. According to the docs<sup>[1]</sup> they will both fail back to `__len__`, checking for a non-zero value. This simple change makes the `Sentinel` always evaluate to False in both Python2 and Python3.

Verification steps:
- [ ] Create a sentinel in Python2 and verify that it evaluates to False
- [ ] Create a sentinel in Python3 and verify that it also evaluates to False

Example output using Python 3.5.2
```
>>> sys.version_info
sys.version_info(major=3, minor=5, micro=2, releaselevel='final', serial=0)
>>> import boltons.typeutils
>>> disabled = boltons.typeutils.make_sentinel('DISABLED')
>>> True if disabled else False
False
```

Thanks!

<sup>[1]</sup> See [Python2 \_\_nonzero\_\_](https://docs.python.org/2/reference/datamodel.html#object.__nonzero__) and [Python3 \_\_bool\_\_](https://docs.python.org/3/reference/datamodel.html#object.__bool__)