### PR TITLE
fix the default arguments of mathutils.clamp

### DIFF
--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -23,6 +23,8 @@ def clamp(x, lower=float('-inf'), upper=float('inf')):
     0
     >>> clamp(101.0, 0, 5)
     5
+    >>> clamp(123, upper=5)
+    5
 
     Similar to `numpy's clip`_ function.
 

--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -5,7 +5,7 @@ from math import ceil as _ceil, floor as _floor
 import bisect
 
 
-def clamp(x, lower=None, upper=None):
+def clamp(x, lower=float('-inf'), upper=float('inf')):
     """Limit a value to a given range.
 
     Args:

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -1,7 +1,9 @@
 
 from pytest import raises
-from boltons.mathutils import ceil, floor
+from boltons.mathutils import clamp, ceil, floor
+import math
 
+INF, NAN = float('inf'), float('nan')
 
 OPTIONS = [1618, 1378, 166, 1521, 2347, 2016, 879, 2123,
            269.3, 1230, 66, 425.2, 250, 2399, 2314, 439,
@@ -12,6 +14,24 @@ OUT_OF_RANGE_UPPER = 2500
 VALID_LOWER = 247
 VALID_UPPER = 2314
 VALID_BETWEEN = 248.5
+
+def test_clamp_examples():
+    """some examples for clamp()"""
+    assert 0 == clamp(0, 0, 1) == clamp(-1, 0, 1)
+    assert 0 == clamp(-1, lower=0)
+    assert 1 == clamp(1, 0, 1) == clamp(5, 0, 1)
+    assert 1 == clamp(5, upper=1)
+    assert 0.5 == clamp(7, upper=0.5)
+    assert 1 == clamp(7.7, upper=1)
+
+def test_clamp_transparent():
+    """clamp(x) should equal x beacause both limits are omitted"""
+    assert clamp(0) == 0
+    assert clamp(1) == 1
+    assert clamp(10**100) == 10**100
+    assert clamp(INF) == INF
+    assert clamp(-INF) == -INF
+    assert math.isnan(clamp(NAN))
 
 
 def test_ceil_basic():


### PR DESCRIPTION
`mathutils.clamp` is supposed to restrict an arbitrary number to the interval given by its last two (optional) arguments. But it is incorrect when not both `lower` and `upper` arguments are given

The default arguments are `None`, which isn't comparable in Python 3 and is less than x for any x in Python 2 (except NaN).

| expression  | Python 2 | Python 3 | fixed |
|---|---|---|---|
| `clamp(1)` |  `None` | raises `TypeError`  | `1` |
| `clamp(1, upper=2)` | `1`  | raises `TypeError` | `1` |
| `clamp(1, lower=0)` | raises `ValueError`  | raises `TypeError` | `1` |

This fixes `mathutils.clamp` by simply using positive infinity and negative infinity as default bounds, and adds two test cases as well as an example in the function's docstring.