### PR TITLE
Allow symbols to be used in type annotations

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -401,8 +401,16 @@ class FunctionBuilder(object):
         @classmethod
         def _argspec_to_dict(cls, f):
             argspec = inspect.getfullargspec(f)
-            return dict((attr, getattr(argspec, attr))
-                        for attr in cls._argspec_defaults)
+            result = dict((attr, getattr(argspec, attr))
+                          for attr in cls._argspec_defaults)
+            escaped_annotations = {}
+            for annotation, value in argspec.annotations.items():
+                if isinstance(value, type):
+                    escaped_annotations[annotation] = value.__name__
+                else:
+                    escaped_annotations[annotation] = str(value)
+            result['annotations'] = escaped_annotations
+            return result
 
     _defaults = {'doc': str,
                  'dict': dict,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ py==1.4.31
 pytest==2.9.2
 pytest-cov==2.3.0
 tox==2.3.1
+typing==3.6.1
 virtualenv==15.0.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,5 +4,5 @@ py==1.4.31
 pytest==2.9.2
 pytest-cov==2.3.0
 tox==2.3.1
-typing==3.6.1
+typing==3.6.1;python_version>"2.6"
 virtualenv==15.0.2

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -1,5 +1,6 @@
 
 import inspect
+from typing import Optional, Tuple
 
 import pytest
 
@@ -24,8 +25,19 @@ def test_wraps_py3():
         return a, b
 
     annotations(0) == (True, "annotations", (0, 1))
-    annotations.__annotations__ == {'a': int, 'b': float,
-                                    'return': 'tuple'}
+    assert annotations.__annotations__ == {'a': 'int', 'b': 'float',
+                                           'return': 'tuple'}
+
+    @pita_wrap(flag=True)
+    def typed_annotations(a: int, b: Optional[int] = 42) -> Tuple[int, int]:
+        return a, b or 0
+
+    typed_annotations(0) == (True, "annotations", (0, 42))
+    assert typed_annotations.__annotations__ == {
+        'a': 'int',
+        'b': 'typing.Union[int, NoneType]',
+        'return': 'Tuple'
+    }
 
     @pita_wrap(flag=False)
     def kwonly_arg(a, *, b, c=2):


### PR DESCRIPTION
PEP 484 states that string literals can be used in place of type declarations:
https://www.python.org/dev/peps/pep-0484/#the-problem-of-forward-declarations

While this is kind of gross, there aren't really any better options unless we want
to blit in `sys.modules` and even then getting that right would be extremely tricky
if we also consider aliases.