### PR TITLE
ioutils: add MultiFileReader to ease concatenation of multiple readers

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -1,15 +1,6 @@
 TODO
 ====
 
-- dummy context manager
-- dummy file
-- urlutils
-
-cacheutils
-----------
-
-- counting dictionary (with sys.modules example)
-
 dictutils
 ---------
 
@@ -32,8 +23,6 @@ misc?
   everything callable, with a hook. Needs an enable/disable flag.
   - get/set/call/return/exception
   - __slots__
-
-- Tracking proxy. An object that always succeeds for all operations, saving the call history.
 - Top/Bottom singletons (greater than and less than everything)
 
 
@@ -53,18 +42,6 @@ statsutils
 
 - dirty bit auto clears cache on property access
 - geometric mean (2 ** sum(log(a, b, ...))
-
-funcutils
----------
-
-#class FunctionDef(object):
-#    """
-#    general blocker: accept a bunch of fine-grained arguments, or just
-#    accept a whole ArgSpec? or a whole signature?
-#    """
-#    def __init__(self, name, code, doc=None):
-#        pass
-
 
 urlutils
 --------

--- a/boltons/ioutils.py
+++ b/boltons/ioutils.py
@@ -407,10 +407,10 @@ class SpooledStringIO(SpooledIOBase):
 
 
 def is_text_fileobj(fileobj):
-    if hasattr(fileobj, 'encoding'):
+    if getattr(fileobj, 'encoding', False):
         # codecs.open and io.TextIOBase
         return True
-    if hasattr(fileobj, 'getvalue'):
+    if getattr(fileobj, 'getvalue', False):
         # StringIO.StringIO / cStringIO.StringIO / io.StringIO
         try:
             if isinstance(fileobj.getvalue(), type(u'')):

--- a/docs/ioutils.rst
+++ b/docs/ioutils.rst
@@ -78,3 +78,13 @@ Here is a simple example using the requests library to download a zip file::
 
                 # Print all the files in the zip
                 print(zip_doc.namelist())
+
+
+Multiple Files
+--------------
+
+.. _multifilereader:
+
+MultiFileReader
+^^^^^^^^^^^^^^^
+.. autoclass:: boltons.ioutils.MultiFileReader

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -4,9 +4,17 @@ import sys
 import codecs
 import random
 import string
+
+try:
+    from StringIO import StringIO
+except:
+    # py3
+    StringIO = io.StringIO
+
 from tempfile import mkdtemp
 from unittest import TestCase
 from zipfile import ZipFile, ZIP_DEFLATED
+
 
 from boltons import ioutils
 
@@ -407,7 +415,9 @@ class TestMultiFileReader(TestCase):
         self.assertEqual(b'narftroz', r.read())
 
     def test_read_seek_text(self):
-        r = ioutils.MultiFileReader(io.StringIO(u'narf'), io.StringIO(u'troz'))
+        # also tests StringIO.StringIO on py2
+        r = ioutils.MultiFileReader(StringIO(u'narf'),
+                                    io.StringIO(u'troz'))
         self.assertEqual([u'nar', u'ftr', u'oz'],
                          list(iter(lambda: r.read(3), u'')))
         r.seek(0)

--- a/tests/test_ioutils.py
+++ b/tests/test_ioutils.py
@@ -410,5 +410,5 @@ class TestMultiFileReader(TestCase):
         self.assertEqual(u'narftroz', r.read())
 
     def test_no_mixed_bytes_and_text(self):
-        with self.assertRaises(ValueError):
-            ioutils.MultiFileReader(io.BytesIO(b'narf'), io.StringIO(u'troz'))
+        self.assertRaises(ValueError, ioutils.MultiFileReader,
+                          io.BytesIO(b'narf'), io.StringIO(u'troz'))

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -313,6 +313,13 @@ def test_navigate():
     assert navd.to_text() == _dest_text
 
 
+# TODO: RFC3986 6.2.3 (not just for query add, either)
+# def test_add_query():
+#     url = URL('http://www.example.com')
+#     url.qp['key'] = 'value'
+#     assert url.to_text() == 'http://www.example.com/?key=value'
+
+
 def test_self_normalize():
     url = URL('http://hatnote.com/a/../../b?k=v#hashtags')
     url.normalize()


### PR DESCRIPTION
I ended up needing something like this for Mercurial, and mhashemirc
suggested that it would make sense in boltons.