### PR TITLE
DeferredValue: fix caching

### DIFF
--- a/boltons/formatutils.py
+++ b/boltons/formatutils.py
@@ -291,10 +291,12 @@ class DeferredValue(object):
         value may be returned depending on the *cache_value* option
         passed to the constructor.
         """
-        if self._value is _UNSET or not self.cache_value:
+        if self._value is not _UNSET and self.cache_value:
+            value = self._value
+        else:
             value = self.func()
-        if self.cache_value:
-            self._value = value
+            if self.cache_value:
+                self._value = value
         return value
 
     def __int__(self):

--- a/tests/test_formatutils.py
+++ b/tests/test_formatutils.py
@@ -6,7 +6,8 @@ from collections import namedtuple
 from boltons.formatutils import (get_format_args,
                                  split_format_str,
                                  tokenize_format_str,
-                                 infer_positional_format_args)
+                                 infer_positional_format_args,
+                                 DeferredValue as DV)
 
 
 PFAT = namedtuple("PositionalFormatArgTest", "fstr arg_vals res")
@@ -62,3 +63,22 @@ def test_tokenize_format_str():
         res = tokenize_format_str(t)
         results.append(res)
     return results
+
+
+def test_deferredvalue():
+    def myfunc():
+        myfunc.called += 1
+        return 123
+
+    myfunc.called = 0
+
+    dv = DV(myfunc)
+    assert str(dv) == '123'
+    assert myfunc.called == 1
+    assert str(dv) == '123'
+    assert myfunc.called == 1
+    dv.cache_value = False
+    assert str(dv) == '123'
+    assert myfunc.called == 2
+    assert str(dv) == '123'
+    assert myfunc.called == 3


### PR DESCRIPTION
It appears as if DeferredValue has been broken since the very beginning.

It tried caching the value by default, but never accessed it raising a NameError when `get_value` was invoked for the second time.