### PR TITLE
remap(): Better exception handling for file object values

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -696,10 +696,6 @@ _orig_default_visit = default_visit
 
 def default_enter(path, key, value):
     # print('enter(%r, %r)' % (key, value))
-    try:
-        iter(value)
-    except (TypeError, ValueError):
-        return value, False
     if isinstance(value, basestring):
         return value, False
     elif isinstance(value, Mapping):
@@ -708,6 +704,14 @@ def default_enter(path, key, value):
         return value.__class__(), enumerate(value)
     elif isinstance(value, Set):
         return value.__class__(), enumerate(value)
+    elif hasattr(value, 'read'):
+        # presume this is a file-like object
+        return value, False
+    else:
+        try:
+            iter(value)
+        except TypeError:
+            return value, False
     return value, False
 
 

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -698,7 +698,7 @@ def default_enter(path, key, value):
     # print('enter(%r, %r)' % (key, value))
     try:
         iter(value)
-    except TypeError:
+    except (TypeError, ValueError):
         return value, False
     if isinstance(value, basestring):
         return value, False


### PR DESCRIPTION
Howdy, 

Ran into this problem today:

I'm using the remap() function to clean "undesired" values from a nested dictionary of values from a Deform form post. One of the values is a file-like object that comes from a File Upload component on a web page.
When remap() hits this value **and** the file-like object has been already read/processed, then a ` ValueError: I/O operation on closed file.` exception is raised.

snippet of the traceback:
```
  File "./cahps_forms_app/views/mega_form.py", line 416, in mail_details
    e.cstruct = remap(e.cstruct, visit=visit)
  File "/home/jsivak/projects/cahps_forms_ve/lib/python3.6/site-packages/boltons/iterutils.py", line 863, in remap
    res = enter(path, key, value)
  File "/home/jsivak/projects/cahps_forms_ve/lib/python3.6/site-packages/boltons/iterutils.py", line 700, in default_enter
    iter(value)
ValueError: I/O operation on closed file. 
```

I'd like to be able to better handle this exception in a different part of my code, so I propose this pull request to add the catching of a ValueError exception in the default_enter() function. This allows the file-like object to be "surfaced" back to my application and I can then better handle the issue.
I've made the change and ran the tests, none broke, but I don't know if you are comfortable with catching the ValueError (or have had previous issues with this type issue).

Let me know if you have any questions.

Thanks for a nice set of tools.