### PR TITLE
Correctly handle RFC2732 IPv6 address literals with ports

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -892,16 +892,19 @@ def parse_url(url_text):
     if hostinfo:
         host, sep, port_str = hostinfo.partition(u':')
         if sep:
-            if u']' in port_str:
-                host = hostinfo  # wrong split, was an ipv6
-            else:
-                try:
-                    port = int(port_str)
-                except ValueError:
-                    if port_str:  # empty ports ok according to RFC 3986 6.2.3
-                        raise URLParseError('expected integer for port, not %r'
-                                            % port_str)
-                    port = None
+            if host[0] == u'[' and u']' in port_str:
+                host_right, _, port_str = port_str.partition(u']')
+                host = host + u':' + host_right + u']'
+                if port_str and port_str[0] == u':':
+                    port_str = port_str[1:]
+
+            try:
+                port = int(port_str)
+            except ValueError:
+                if port_str:  # empty ports ok according to RFC 3986 6.2.3
+                    raise URLParseError('expected integer for port, not %r'
+                                        % port_str)
+                port = None
 
     family, host = parse_host(host)
 

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -892,7 +892,7 @@ def parse_url(url_text):
     if hostinfo:
         host, sep, port_str = hostinfo.partition(u':')
         if sep:
-            if host[0] == u'[' and u']' in port_str:
+            if host and host[0] == u'[' and u']' in port_str:
                 host_right, _, port_str = port_str.partition(u']')
                 host = host + u':' + host_right + u']'
                 if port_str and port_str[0] == u':':


### PR DESCRIPTION
It does not appear that the `boltons.urlutils.URL` class is properly handling IPv6 literal addresses (as defined in [RFC 2732](https://tools.ietf.org/html/rfc2732)) that specify ports. This is due to how the host string is being parsed in `boltons.urlutils.parse_url`.

For example before this patch (example specifies IPv6 address `::1` with port `8080`):
```
In [2]: pprint.pprint(urlutils.parse_url('tcp://[::1]:8080/'))
{'_netloc_sep': '//',
 'authority': '[::1]:8080',
 'family': None,
 'fragment': None,
 'host': '[::1]:8080',
 'password': None,
 'path': '/',
 'port': None,
 'query': None,
 'scheme': 'tcp',
 'username': None}
```

After this patch:
```
In [1]: import pprint; from boltons import urlutils

In [2]: pprint.pprint(urlutils.parse_url('tcp://[::1]:8080/'))
{'_netloc_sep': '//',
 'authority': '[::1]:8080',
 'family': <AddressFamily.AF_INET6: 10>,
 'fragment': None,
 'host': '::1',
 'password': None,
 'path': '/',
 'port': 8080,
 'query': None,
 'scheme': 'tcp',
 'username': None}
```

Note the differences in the `family`, `host`, and `port` keys of the resulting dictionary.
