### PR TITLE
Cache utils yield keyerrors when at limit.

### DIFF
--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -30,6 +30,20 @@ def test_lri():
     assert len(bc) == 10
 
 
+def test_lri_eviction():
+    cache = LRI(max_size=10)
+    for char in string.ascii_letters:
+        cache[char] == char.upper()
+    assert len(cache) == 10
+
+
+def test_lru_eviction():
+    cache = LRU(max_size=10)
+    for char in string.ascii_letters:
+        cache[char] == char.upper()
+    assert len(cache) == 10
+
+
 def test_lru_basic():
     lru = LRU(max_size=1)
     repr(lru)                   # sanity


### PR DESCRIPTION
- The LRU and LRI caches hit a key error when trying
  to evict; this patch adds a test for this behavior.

I haven't dug into a fix for this yet.