### PR TITLE
Fix issue evicting duplicate keys from LRI (#155)

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -351,10 +351,11 @@ class LRI(dict):
 
     def __setitem__(self, key, value):
         # TODO: pop support (see above)
-        if len(self) >= self.max_size:
-            old = self._queue.popleft()
-            del self[old]
         super(LRI, self).__setitem__(key, value)
+        while len(self) > self.max_size:
+            # Keep attempting to remove the least recently inserted
+            # items until we are under max_size.
+            self.pop(self._queue.popleft())
         self._queue.append(key)
 
     def update(self, E, **F):

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -97,6 +97,13 @@ def test_lru_basic():
     assert second_lru != lru
 
 
+def test_lri_with_dupes():
+    cache = LRI(max_size=2)
+    for char in ('a', 'b', 'c'):
+        cache[char] = char
+        cache[char] = char
+
+
 def test_lru_with_dupes():
     SIZE = 2
     lru = LRU(max_size=SIZE)


### PR DESCRIPTION
The insertion deque() can have duplicate items when the same key is set
multiple times. The eviction routine assumes the cache item still exists
and so can raise KeyError. This patch modifies the LRI setitem method
to use dict.pop(key) instead of del[key] so as to avoid the KeyError.

The eviction is now run in a while loop until the cache is less than or
equal to max_size since the dict.pop() eviction is not guaranteed to
actually evict anything.