### PR TITLE
Add MultiSub tool for single pass substitutions

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1037,7 +1037,7 @@ class MultiSub(object):
             self.sub_data.append((exp, replacement))
 
         self.combined_pattern = re.compile('|'.join([
-            '(?:{})'.format(x.pattern) for x, _
+            '(?:{0})'.format(x.pattern) for x, _
             in self.sub_data
         ]))
 

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1026,22 +1026,24 @@ class MultiSub(object):
 
     def __init__(self, sub_map):
         """Compile any regular expressions that have been passed."""
-        self.sub_map = collections.OrderedDict()
-        if not isinstance(sub_map, collections.Mapping):
-            sub_map = collections.OrderedDict(sub_map)
-        for exp, replacement in collections.OrderedDict(sub_map).items():
+        self.sub_data = []
+
+        if isinstance(sub_map, collections.Mapping):
+            sub_map = sub_map.items()
+
+        for exp, replacement in sub_map:
             if isinstance(exp, basestring):
                 exp = re.compile(exp)
-            self.sub_map[exp] = replacement
+            self.sub_data.append((exp, replacement))
 
         self.combined_pattern = re.compile('|'.join([
-            '(?:{})'.format(x.pattern) for x
-            in self.sub_map.keys()
+            '(?:{})'.format(x.pattern) for x, _
+            in self.sub_data
         ]))
 
     def __call__(self, match):
         value = match.string[match.start():match.end()]
-        for exp, replacement in self.sub_map.items():
+        for exp, replacement in self.sub_data:
             if exp.match(value):
                 return replacement
         return value

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -47,25 +47,35 @@ def test_format_int_list():
     assert strutils.format_int_list([5, 6, 7, 8], delim_space=True) == '5-8'
 
 
-class TestMultiSub(TestCase):
+class TestMultiReplace(TestCase):
 
     def test_simple_substitutions(self):
         """Test replacing multiple values."""
-        m = strutils.MultiSub({r'cat': 'kedi', r'purple': 'mor', })
+        m = strutils.MultiReplace({r'cat': 'kedi', r'purple': 'mor', })
         self.assertEqual(m.sub('The cat is purple'), 'The kedi is mor')
+
+    def test_shortcut_function(self):
+        """Test replacing multiple values."""
+        self.assertEqual(
+            strutils.multi_replace(
+                'The cat is purple',
+                {r'cat': 'kedi', r'purple': 'mor', }
+            ),
+            'The kedi is mor'
+        )
 
     def test_substitutions_in_word(self):
         """Test replacing multiple values that are substrings of a word."""
-        m = strutils.MultiSub({r'cat': 'kedi', r'purple': 'mor', })
+        m = strutils.MultiReplace({r'cat': 'kedi', r'purple': 'mor', })
         self.assertEqual(m.sub('Thecatispurple'), 'Thekediismor')
 
     def test_sub_with_regex(self):
         """Test substitutions with a regular expression."""
-        m = strutils.MultiSub({
+        m = strutils.MultiReplace({
             r'cat': 'kedi',
             r'purple': 'mor',
             r'q\w+?t': 'dinglehopper'
-        })
+        }, regex=True)
         self.assertEqual(
             m.sub('The purple cat ate a quart of jelly'),
             'The mor kedi ate a dinglehopper of jelly'
@@ -73,11 +83,11 @@ class TestMultiSub(TestCase):
 
     def test_sub_with_list(self):
         """Test substitutions from an iterable instead of a dictionary."""
-        m = strutils.MultiSub([
+        m = strutils.MultiReplace([
             (r'cat', 'kedi'),
             (r'purple', 'mor'),
             (r'q\w+?t', 'dinglehopper'),
-        ])
+        ], regex=True)
         self.assertEqual(
             m.sub('The purple cat ate a quart of jelly'),
             'The mor kedi ate a dinglehopper of jelly'
@@ -86,7 +96,7 @@ class TestMultiSub(TestCase):
     def test_sub_with_compiled_regex(self):
         """Test substitutions where some regular expressiosn are compiled."""
         exp = re.compile(r'q\w+?t')
-        m = strutils.MultiSub([
+        m = strutils.MultiReplace([
             (r'cat', 'kedi'),
             (r'purple', 'mor'),
             (exp, 'dinglehopper'),
@@ -95,3 +105,8 @@ class TestMultiSub(TestCase):
             m.sub('The purple cat ate a quart of jelly'),
             'The mor kedi ate a dinglehopper of jelly'
         )
+
+    def test_substitutions_with_regex_chars(self):
+        """Test replacing values that have special regex characters."""
+        m = strutils.MultiReplace({'cat.+': 'kedi', r'purple': 'mor', })
+        self.assertEqual(m.sub('The cat.+ is purple'), 'The kedi is mor')


### PR DESCRIPTION
MultiSub leverages regular expressions and the sub
module to perform a series of multiple replacements
in a string in a single pass.

For example:

long_string = long_string.replace('foo', 'bar')
long_string = long_string.replace('baz', 'fizz')
long_string = long_string.replace('bang', 'lame')

.... and so on - can get tedious and requires multiple
passes over the same string value.

The multisub equivilant would be:

m = MultiSub({
    'foo': 'bar',
    'baz': 'fizz',
    'bang': 'lame',
)
long_string = m.sub(long_string)

The longer the string in question the more of a
performance increase you'll see relative to a series
of calls to .replace