### PR TITLE
Include license file in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include CHANGELOG.md
+include LICENSE
+include README.md
+include TODO.rst
+include pytest.ini
+include tox.ini
+recursive-include docs 
+recursive-include tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The license requires that all copies of the software include the license text. These patches make sure sdists and wheels include the license text. Without this, other people cannot legally redistribute the software.

Fixes #156.