### PR TITLE
Add conda-forge and python versions badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <a href="https://boltons.readthedocs.io/en/latest/"><img src="https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat"></a>
 <a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/v/boltons.svg"></a>
+<a href="https://anaconda.org/conda-forge/boltons"><img src="https://img.shields.io/conda/vn/conda-forge/boltons.svg"></a>
+<a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/pyversions/boltons.svg"></a>
 <a href="http://calver.org"><img src="https://img.shields.io/badge/calver-YY.MINOR.MICRO-22bfda.svg"></a>
 
 **Boltons** is a set of over 160 BSD-licensed, pure-Python utilities


### PR DESCRIPTION
Adds badges for [conda-forge](https://github.com/conda-forge/boltons-feedstock) (maintained by myself and a few others) and a Python versions badge, which shows the supported Python versions at a glance.