### PR TITLE
Travis CI: Drop EOL Pythons, Upgrade to Py 3.7, 3.8-dev, and current PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,24 @@ python:
  
   # PyPy2.7: https://doc.pypy.org/en/latest
   # /index-of-release-notes.html#cpython-2-7-compatible-versions
-  - pypy         # Python 2.7.13 on PyPy 5.8.0
-  - pypy-6.0.0   # Python 2.7.13 on PyPy 6.0.0
+  - pypy          # Python 2.7.13 on PyPy 5.8.0
+  #- pypy-6.0.0   # Python 2.7.13 on PyPy 6.0.0  # Travis needs to upgrade!
 
   # PyPy3.3: https://doc.pypy.org/en/latest
   # /index-of-release-notes.html#cpython-3-3-compatible-versions
-  - pypy3        # Python 3.5.3 on PyPy 5.8.0
-  - pypy3-6.0.0  # Python 3.5.3 on PyPy 6.0.0
+  - pypy3         # Python 3.5.3 on PyPy PyPy 5.8.0-beta0
+  #- pypy3-6.0.0  # Python 3.5.3 on PyPy 6.0.0  # Travis needs to upgrade!
 
 matrix:
   include:
     - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial     # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required   # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: nightly  # Python 3.8.0a0
+      dist: xenial     # required for Python 3.8-dev (travis-ci/travis-ci#9069)
+      sudo: required   # required for Python 3.8-dev (travis-ci/travis-ci#9069)
+  allow_failures:
     - python: nightly
-      dist: xenial    # required for Python 3.8-dev (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.8-dev (travis-ci/travis-ci#9069)
 
 install: "pip install -r requirements-test.txt"
 script: "py.test --doctest-modules boltons tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,31 @@ cache: pip
 python:
   # Standard release https://docs.travis-ci.com/user/languages
   # /python#choosing-python-versions-to-test-against
-  - "2.6"
+  # - "2.6"  # EOL: https://devguide.python.org/#branchstatus
   - "2.7"
-  - "3.3"
+  # - "3.3"  # EOL: https://devguide.python.org/#branchstatus
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"  # a.k.a "nightly"
-
+ 
   # PyPy2.7: https://doc.pypy.org/en/latest
   # /index-of-release-notes.html#cpython-2-7-compatible-versions
-  - pypy  # PyPy2.7 2.5.0
-  - pypy-5.1
-  - pypy-5.3
-  - pypy-5.4
+  - pypy         # Python 2.7.13 on PyPy 5.8.0
+  - pypy-6.0.0   # Python 2.7.13 on PyPy 6.0.0
 
   # PyPy3.3: https://doc.pypy.org/en/latest
   # /index-of-release-notes.html#cpython-3-3-compatible-versions
-  - pypy3.3-5.2-alpha1
+  - pypy3        # Python 3.5.3 on PyPy 5.8.0
+  - pypy3-6.0.0  # Python 3.5.3 on PyPy 6.0.0
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: nightly
+      dist: xenial    # required for Python 3.8-dev (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.8-dev (travis-ci/travis-ci#9069)
 
 install: "pip install -r requirements-test.txt"
 script: "py.test --doctest-modules boltons tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ cache: pip
 python:
   # Standard release https://docs.travis-ci.com/user/languages
   # /python#choosing-python-versions-to-test-against
-  # - "2.6"  # EOL: https://devguide.python.org/#branchstatus
+  - "2.6"  # EOLed 5 years ago. https://www.python.org/dev/peps/pep-0361/#release-lifespan
   - "2.7"
-  # - "3.3"  # EOL: https://devguide.python.org/#branchstatus
   - "3.4"
   - "3.5"
   - "3.6"
@@ -20,7 +19,7 @@ python:
   - pypy          # Python 2.7.13 on PyPy 5.8.0
   #- pypy-6.0.0   # Python 2.7.13 on PyPy 6.0.0  # Travis needs to upgrade!
 
-  # PyPy3.3: https://doc.pypy.org/en/latest
+  # PyPy3.5: https://doc.pypy.org/en/latest
   # /index-of-release-notes.html#cpython-3-3-compatible-versions
   - pypy3         # Python 3.5.3 on PyPy PyPy 5.8.0-beta0
   #- pypy3-6.0.0  # Python 3.5.3 on PyPy 6.0.0  # Travis needs to upgrade!


### PR DESCRIPTION
Upgrade to the _production_ version of Python 3.7 in alignment with travis-ci/travis-ci#9069

Also see the note about outdated Python versions at:
* https://docs.travis-ci.com/user/languages/python/#development-releases-support

Created #175 to highlight test failures on CPython 3.8.0.a0.