### PR TITLE
Tox and Appveryor: Upgrade to Python 3.7 and drop 2.6 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,7 @@ init:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox"
-  - "%PYTHON%/Scripts/pip install wheel"
+  - "%PYTHON%/Scripts/pip install tox wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python35-x64"
-      TOX_ENV: "py35"
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: "py37"
 
 
 init:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py36,pypy
+envlist = py27,py34,py37,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py37,pypy
+envlist = py26,py27,py34,py37,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt


### PR DESCRIPTION
Python 2.6 was EOLed 5 years ago.  https://www.python.org/dev/peps/pep-0361/#release-lifespan