### PR TITLE
Fix bug in implementation of `timeutils.daterange`

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -348,7 +348,7 @@ def daterange(start, stop, step=1, inclusive=False):
                          ' (year, month, day), not: %r' % step)
 
     if stop is None:
-        finished = lambda t: False
+        finished = lambda now, stop: False
     elif start < stop:
         finished = operator.gt if inclusive else operator.ge
     else:

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -47,3 +47,9 @@ def test_daterange_years():
 
     assert years_from_2025[0] == date(2025, 1, 1)
     assert years_from_2025[-1] == date(2017, 1, 1)
+
+def test_daterange_infinite():
+    today = date.today()
+    infinite_dates = daterange(today, None)
+    for i in range(10):
+        assert next(infinite_dates) == today + timedelta(days=i)


### PR DESCRIPTION
Currently, the `finished` function used in case of `stop` being None has a
different signature than the one used in case of `stop` being a date.
This commit remedies that and adds a test for the same.