### PR TITLE
Add a __str__ function to boltons.urlutils.URL

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -770,6 +770,12 @@ class URL(object):
         cn = self.__class__.__name__
         return u'%s(%r)' % (cn, self.to_text())
 
+    def __str__(self):
+        return self.to_text()
+
+    def __unicode__(self):
+        return self.to_text()
+
     def __eq__(self, other):
         for attr in self._cmp_attrs:
             if not getattr(self, attr) == getattr(other, attr, None):

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -463,3 +463,6 @@ def test_unicodey():
     assert url.to_text(full_quote=False) == unicodey
     fully_quoted = 'http://xn--9ca.com/%C3%A9?%C3%A1=%C3%AD#%C3%BA'
     assert url.to_text(full_quote=True) == fully_quoted
+
+def test_str_repr():
+    assert str(URL("http://googlewebsite.com/e-shops.aspx")) == "http://googlewebsite.com/e-shops.aspx"


### PR DESCRIPTION
This adds a `__str__` (and `__unicode__`) function to URL class which
returns a str representation of the url like `to_text()`.
Fixes #182.