### PR TITLE
Add **kwargs to IndexedSet.sort

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -402,9 +402,9 @@ class IndexedSet(MutableSet):
             self.item_index_map[item] = i
         del self.dead_indices[:]
 
-    def sort(self):
+    def sort(self, **kwargs):
         "sort() -> sort the contents of the set in-place"
-        sorted_list = sorted(self)
+        sorted_list = sorted(self, **kwargs)
         if sorted_list == self.item_list:
             return
         self.item_list[:] = sorted_list


### PR DESCRIPTION
The class method `setutils.IndexedSet.sort` does not take any arguments, but its code uses the built-in `sorted`, which does take several keyword arguments. This simple change will make the method pass its `**kwargs` to `sorted`, which can be quite useful. For instance, it will allow one to define a [key function](https://docs.python.org/2/howto/sorting.html#key-functions). The following is a list of `sorted` options (in Python 2.7).

```
Help on built-in function sorted in module __builtin__:

sorted(...)
    sorted(iterable, cmp=None, key=None, reverse=False) --> new sorted list
```

Example of the usage is:
```
S = IndexedSet([1, 2, 3, 4])
S.sort(key = lambda s: -s)
print(S)
>> IndexedSet([4, 3, 2, 1])
```