### PR TITLE
Fix warnings in python3.7

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -38,7 +38,10 @@ thanks to `Mark Williams`_ for all his help.
 
 """
 
-from collections import KeysView, ValuesView, ItemsView
+try:
+    from collections.abc import KeysView, ValuesView, ItemsView
+except ImportError:
+    from collections import KeysView, ValuesView, ItemsView
 
 try:
     from itertools import izip_longest

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -19,7 +19,11 @@ import socket
 import hashlib
 import itertools
 
-from collections import Mapping, Sequence, Set, ItemsView, Iterable
+try:
+    from collections.abc import Mapping, Sequence, Set, ItemsView, Iterable
+except ImportError:
+    from collections import Mapping, Sequence, Set, ItemsView, Iterable
+
 
 try:
     from typeutils import make_sentinel

--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -14,8 +14,12 @@ from __future__ import print_function
 
 from bisect import bisect_left
 from itertools import chain, islice
-from collections import MutableSet
 import operator
+
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 
 try:
     from typeutils import make_sentinel

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -16,6 +16,11 @@ import unicodedata
 import collections
 
 try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
+try:
     unicode, str, bytes, basestring = unicode, str, str, basestring
     from HTMLParser import HTMLParser
     import htmlentitydefs
@@ -1045,7 +1050,7 @@ class MultiReplace(object):
         self.group_map = {}
         regex_values = []
 
-        if isinstance(sub_map, collections.Mapping):
+        if isinstance(sub_map, Mapping):
             sub_map = sub_map.items()
 
         for idx, vals in enumerate(sub_map):

--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -21,10 +21,16 @@ For more advanced :class:`Table`-style manipulation check out the
 
 from __future__ import print_function
 
-import cgi
+try:
+    from html import escape as html_escape
+except ImportError:
+    from cgi import escape as html_escape
 import types
 from itertools import islice
-from collections import Sequence, Mapping, MutableSequence
+try:
+    from collections.abc import Sequence, Mapping, MutableSequence
+except ImportError:
+    from collections import Sequence, Mapping, MutableSequence
 try:
     string_types, integer_types = (str, unicode), (int, long)
     from cgi import escape as html_escape

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -949,7 +949,10 @@ def parse_qsl(qs, keep_blank_values=True, encoding=DEFAULT_ENCODING):
 # 20161021, used for the QueryParamDict, toward the bottom.
 """
 
-from collections import KeysView, ValuesView, ItemsView
+try:
+    from collections.abc import KeysView, ValuesView, ItemsView
+except ImportError:
+    from collections import KeysView, ValuesView, ItemsView
 
 try:
     from itertools import izip_longest


### PR DESCRIPTION
Importing Abstract Base Classes from `collections` instead of `collections.abc` is deprecated and will stop working in python 3.8. This modifies all such instances in the code to import from `collections.abc` first and only use `collections` as a fallback for older versions.