### PR TITLE
Fix issues with LRI Cache #155

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -70,17 +70,16 @@ PREV, NEXT, KEY, VALUE = range(4)   # names for the link fields
 DEFAULT_MAX_SIZE = 128
 
 
-class LRU(dict):
-    """The ``LRU`` is :class:`dict` subtype implementation of the
-    *Least-Recently Used* caching strategy.
+class LRI(dict):
+    """The ``LRI`` implements the basic *Least Recently Inserted* strategy to
+    caching. One could also think of this as a ``SizeLimitedDefaultDict``.
 
-    Args:
-        max_size (int): Max number of items to cache. Defaults to ``128``.
-        values (iterable): Initial values for the cache. Defaults to ``None``.
-        on_miss (callable): a callable which accepts a single argument, the
-            key not present in the cache, and returns the value to be cached.
+    *on_miss* is a callable that accepts the missing key (as opposed
+    to :class:`collections.defaultdict`'s "default_factory", which
+    accepts no arguments.) Also note that, like the :class:`LRI`,
+    the ``LRI`` is instrumented with statistics tracking.
 
-    >>> cap_cache = LRU(max_size=2)
+    >>> cap_cache = LRI(max_size=2)
     >>> cap_cache['a'], cap_cache['b'] = 'A', 'B'
     >>> from pprint import pprint as pp
     >>> pp(dict(cap_cache))
@@ -90,19 +89,8 @@ class LRU(dict):
     >>> cap_cache['c'] = 'C'
     >>> print(cap_cache.get('a'))
     None
-
-    This cache is also instrumented with statistics
-    collection. ``hit_count``, ``miss_count``, and ``soft_miss_count``
-    are all integer members that can be used to introspect the
-    performance of the cache. ("Soft" misses are misses that did not
-    raise :exc:`KeyError`, e.g., ``LRU.get()`` or ``on_miss`` was used to
-    cache a default.
-
     >>> cap_cache.hit_count, cap_cache.miss_count, cap_cache.soft_miss_count
     (3, 1, 1)
-
-    Other than the size-limiting caching behavior and statistics,
-    ``LRU`` acts like its parent class, the built-in Python :class:`dict`.
     """
     def __init__(self, max_size=DEFAULT_MAX_SIZE, values=None,
                  on_miss=None):
@@ -139,15 +127,21 @@ class LRU(dict):
         self._anchor = anchor
 
     def _print_ll(self):
-        link = self._anchor
         print('***')
+        for (key, val) in flattened_ll:
+            print(key, val)
+        print('***')
+        return
+
+    def _get_flattened_ll(self):
+        flattened_list = []
+        link = self._anchor
         while True:
-            print(link[KEY], link[VALUE])
+            flattened_list.append((link[KEY], link[VALUE]))
             link = link[NEXT]
             if link is self._anchor:
                 break
-        print('***')
-        return
+        return flattened_list
 
     def _get_link_and_move_to_front_of_ll(self, key):
         # find what will become the newest link. this may raise a
@@ -210,15 +204,15 @@ class LRU(dict):
                     self._set_key_and_add_to_front_of_ll(key, value)
                 else:
                     evicted = self._set_key_and_evict_last_in_ll(key, value)
-                    super(LRU, self).__delitem__(evicted)
-                super(LRU, self).__setitem__(key, value)
+                    super(LRI, self).__delitem__(evicted)
+                super(LRI, self).__setitem__(key, value)
             else:
                 link[VALUE] = value
 
     def __getitem__(self, key):
         with self._lock:
             try:
-                link = self._get_link_and_move_to_front_of_ll(key)
+                link = self._link_lookup[key]
             except KeyError:
                 self.miss_count += 1
                 if not self.on_miss:
@@ -238,14 +232,14 @@ class LRU(dict):
 
     def __delitem__(self, key):
         with self._lock:
-            super(LRU, self).__delitem__(key)
+            super(LRI, self).__delitem__(key)
             self._remove_from_ll(key)
 
     def pop(self, key, default=_MISSING):
         # NB: hit/miss counts are bypassed for pop()
         with self._lock:
             try:
-                ret = super(LRU, self).pop(key)
+                ret = super(LRI, self).pop(key)
             except KeyError:
                 if default is _MISSING:
                     raise
@@ -256,13 +250,13 @@ class LRU(dict):
 
     def popitem(self):
         with self._lock:
-            item = super(LRU, self).popitem()
+            item = super(LRI, self).popitem()
             self._remove_from_ll(item[0])
             return item
 
     def clear(self):
         with self._lock:
-            super(LRU, self).clear()
+            super(LRI, self).clear()
             self._init_ll()
 
     def copy(self):
@@ -299,29 +293,30 @@ class LRU(dict):
                 return True
             if len(other) != len(self):
                 return False
-            if not isinstance(other, LRU):
+            if not isinstance(other, LRI):
                 return other == self
-            return super(LRU, self).__eq__(other)
+            return super(LRI, self).__eq__(other)
 
     def __ne__(self, other):
         return not (self == other)
 
     def __repr__(self):
         cn = self.__class__.__name__
-        val_map = super(LRU, self).__repr__()
+        val_map = super(LRI, self).__repr__()
         return ('%s(max_size=%r, on_miss=%r, values=%s)'
                 % (cn, self.max_size, self.on_miss, val_map))
 
-class LRI(LRU):
-    """The ``LRI`` implements the basic *Least Recently Inserted* strategy to
-    caching. One could also think of this as a ``SizeLimitedDefaultDict``.
+class LRU(LRI):
+    """The ``LRU`` is :class:`dict` subtype implementation of the
+    *Least-Recently Used* caching strategy.
 
-    *on_miss* is a callable that accepts the missing key (as opposed
-    to :class:`collections.defaultdict`'s "default_factory", which
-    accepts no arguments.) Also note that, like the :class:`LRU`,
-    the ``LRI`` is instrumented with statistics tracking.
+    Args:
+        max_size (int): Max number of items to cache. Defaults to ``128``.
+        values (iterable): Initial values for the cache. Defaults to ``None``.
+        on_miss (callable): a callable which accepts a single argument, the
+            key not present in the cache, and returns the value to be cached.
 
-    >>> cap_cache = LRI(max_size=2)
+    >>> cap_cache = LRU(max_size=2)
     >>> cap_cache['a'], cap_cache['b'] = 'A', 'B'
     >>> from pprint import pprint as pp
     >>> pp(dict(cap_cache))
@@ -331,13 +326,24 @@ class LRI(LRU):
     >>> cap_cache['c'] = 'C'
     >>> print(cap_cache.get('a'))
     None
+
+    This cache is also instrumented with statistics
+    collection. ``hit_count``, ``miss_count``, and ``soft_miss_count``
+    are all integer members that can be used to introspect the
+    performance of the cache. ("Soft" misses are misses that did not
+    raise :exc:`KeyError`, e.g., ``LRU.get()`` or ``on_miss`` was used to
+    cache a default.
+
     >>> cap_cache.hit_count, cap_cache.miss_count, cap_cache.soft_miss_count
     (3, 1, 1)
+
+    Other than the size-limiting caching behavior and statistics,
+    ``LRU`` acts like its parent class, the built-in Python :class:`dict`.
     """
     def __getitem__(self, key):
         with self._lock:
             try:
-                link = self._link_lookup[key]
+                link = self._get_link_and_move_to_front_of_ll(key)
             except KeyError:
                 self.miss_count += 1
                 if not self.on_miss:

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -81,10 +81,10 @@ def test_cache_sizes_on_repeat_insertions():
     """
     Regression test
     Original LRI implementation had an unbounded size of memory
-    regardless of the value for it's `max_size` parameter due to a naive
+    regardless of the value for its `max_size` parameter due to a naive
     insertion algorithm onto an underlying deque data structure. To
     prevent memory leaks, this test will assert that a cache does not
-    grow past it's max size given values of a uniform memory footprint
+    grow past its max size given values of a uniform memory footprint
     """
     caches_to_test = (LRU, LRI)
     for cache_type in caches_to_test:
@@ -92,19 +92,12 @@ def test_cache_sizes_on_repeat_insertions():
         # note strings are used to force allocation of memory
         test_cache["key1"] = "1"
         test_cache["key2"] = "1"
-        # sys.getsizeof object does not fully capture memory footprint
-        initial_key_sizes = {
-            k: sys.getsizeof(test_cache.__dict__[k])
-            for k in test_cache.__dict__
-        }
+        initial_list_size = len(test_cache._get_flattened_ll())
         for k in test_cache:
             for __ in range(100):
                 test_cache[k] = "1"
-        key_sizes_after_inserts = {
-            k: sys.getsizeof(test_cache.__dict__[k])
-            for k in test_cache.__dict__
-        }
-        assert initial_key_sizes == key_sizes_after_inserts
+        list_size_after_inserts = len(test_cache._get_flattened_ll())
+        assert initial_list_size == list_size_after_inserts
 
 
 def test_lru_basic():


### PR DESCRIPTION
Adds failing tests to exercise issues with LRI

To fix the issue, I have a trivial solution that has LRI inherit from LRU.  After a couple hours of thinking about it I don't think there's a faster solution that using the linked list that LRU uses without introducing an unbounded memory size of the underlying datastructure stored.

That being said LRU has a bunch of thread locking logic that I'm uncertain you would want to add to the LRI cache.  So the current solution is more of a conversation piece. Open to feedback on how to go forward on this:
1. Extract common logic from LRU and have LRI and LRU utilize that? (lets us omit thread safety from LRI if we want)
2. Keep naive solution (though thread locking might introduce unwanted overhead).
3. Maybe make thread safety an optional feature on both LRU and LRI. Would be tricky not to break existing features. Probably would require names like: LRU, ThreadUnsafeLRU, LRI, ThreadSafeLRI.