### PR TITLE
Fix incorrect substitution of flatten_iter() and flatten() in docstring

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -742,7 +742,7 @@ def flatten_iter(iterable):
             yield item
 
 def flatten(iterable):
-    """``flatten_iter()`` returns a collapsed list of all the elements from
+    """``flatten()`` returns a collapsed list of all the elements from
     *iterable* while collapsing any nested iterables.
 
     >>> nested = [[1, 2], [[3], [4, 5]]]


### PR DESCRIPTION
This PR just fixes an incorrect reference to `iterutils.flatten_iter()` in the `iterutils.flatten()` docstring.