### PR TITLE
Docstring: FunctionBuilder 'default' argument should be a tuple

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -418,7 +418,8 @@ class FunctionBuilder(object):
         varkw (str): Name of the catch-all variable for keyword
             arguments. E.g., "kwargs" if the resultant function is to have
             ``**kwargs`` in the signature. Defaults to None.
-        defaults (dict): A mapping of argument names to default values.
+        defaults (tuple): A tuple containing default argument values for
+            those arguments that have defaults.
         kwonlyargs (list): Argument names which are only valid as
             keyword arguments. **Python 3 only.**
         kwonlydefaults (dict): A mapping, same as normal *defaults*,


### PR DESCRIPTION
In the docstring, it's mentionned that `defaults` must be a dict. But an error is raised when we pass a dict to `defaults`:

```
  File ".../site-packages/boltons/funcutils.py", line 616, in get_func
    func.__defaults__ = self.defaults
TypeError: __defaults__ must be set to a tuple object
```

The description in this PR is copied from https://docs.python.org/3/reference/datamodel.html (search for __defaults__)

It's the same for python 2 and 3.

