### PR TITLE
Use idiomatic approach for `is_iterable` method

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -71,7 +71,7 @@ def is_scalar(obj):
     >>> is_scalar('hello')
     True
     """
-    return not is_iterable(obj) or isinstance(obj, basestring)
+    return not isinstance(obj, Iterable) or isinstance(obj, basestring)
 
 
 def is_collection(obj):
@@ -85,7 +85,7 @@ def is_collection(obj):
     >>> is_collection('hello')
     False
     """
-    return is_iterable(obj) and not isinstance(obj, basestring)
+    return isinstance(obj, Iterable) and not isinstance(obj, basestring)
 
 
 def split(src, sep=None, maxsplit=None):

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -55,11 +55,7 @@ def is_iterable(obj):
 
     .. _iterable: https://docs.python.org/2/glossary.html#term-iterable
     """
-    try:
-        iter(obj)
-    except TypeError:
-        return False
-    return True
+    return isinstance(obj, Iterable)
 
 
 def is_scalar(obj):


### PR DESCRIPTION
Use idiomatic Python code instead of `try-except`.

That also makes `iterutils` consistent -- some methods used `isinstance(obj, Iterable)` and some used `try-except`.

Also for common methods (`is_scalar` and `is_collection`) use code directly, without `is_iterable`.