### PR TITLE
Fix formatargspec deprecation warning

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -786,55 +786,57 @@ except ImportError:
                 setattr(cls, opname, opfunc)
         return cls
 
+if not _IS_PY2:
+    # copied from python 3 implementation without deprecation warning
+    def formatargspec(args, varargs=None, varkw=None, defaults=None,
+                    kwonlyargs=(), kwonlydefaults={}, annotations={},
+                    formatarg=str,
+                    formatvarargs=lambda name: '*' + name,
+                    formatvarkw=lambda name: '**' + name,
+                    formatvalue=lambda value: '=' + repr(value),
+                    formatreturns=lambda text: ' -> ' + text,
+                    formatannotation=inspect.formatannotation):
+        """Format an argument spec from the values returned by getfullargspec.
 
-def formatargspec(args, varargs=None, varkw=None, defaults=None,
-                  kwonlyargs=(), kwonlydefaults={}, annotations={},
-                  formatarg=str,
-                  formatvarargs=lambda name: '*' + name,
-                  formatvarkw=lambda name: '**' + name,
-                  formatvalue=lambda value: '=' + repr(value),
-                  formatreturns=lambda text: ' -> ' + text,
-                  formatannotation=inspect.formatannotation):
-    """Format an argument spec from the values returned by getfullargspec.
+        The first seven arguments are (args, varargs, varkw, defaults,
+        kwonlyargs, kwonlydefaults, annotations).  The other five arguments
+        are the corresponding optional formatting functions that are called to
+        turn names and values into strings.  The last argument is an optional
+        function to format the sequence of arguments.
 
-    The first seven arguments are (args, varargs, varkw, defaults,
-    kwonlyargs, kwonlydefaults, annotations).  The other five arguments
-    are the corresponding optional formatting functions that are called to
-    turn names and values into strings.  The last argument is an optional
-    function to format the sequence of arguments.
+        Deprecated since Python 3.5: use the `signature` function and `Signature`
+        objects.
+        """
 
-    Deprecated since Python 3.5: use the `signature` function and `Signature`
-    objects.
-    """
-
-    def formatargandannotation(arg):
-        result = formatarg(arg)
-        if arg in annotations:
-            result += ': ' + formatannotation(annotations[arg])
-        return result
-    specs = []
-    if defaults:
-        firstdefault = len(args) - len(defaults)
-    for i, arg in enumerate(args):
-        spec = formatargandannotation(arg)
-        if defaults and i >= firstdefault:
-            spec = spec + formatvalue(defaults[i - firstdefault])
-        specs.append(spec)
-    if varargs is not None:
-        specs.append(formatvarargs(formatargandannotation(varargs)))
-    else:
-        if kwonlyargs:
-            specs.append('*')
-    if kwonlyargs:
-        for kwonlyarg in kwonlyargs:
-            spec = formatargandannotation(kwonlyarg)
-            if kwonlydefaults and kwonlyarg in kwonlydefaults:
-                spec += formatvalue(kwonlydefaults[kwonlyarg])
+        def formatargandannotation(arg):
+            result = formatarg(arg)
+            if arg in annotations:
+                result += ': ' + formatannotation(annotations[arg])
+            return result
+        specs = []
+        if defaults:
+            firstdefault = len(args) - len(defaults)
+        for i, arg in enumerate(args):
+            spec = formatargandannotation(arg)
+            if defaults and i >= firstdefault:
+                spec = spec + formatvalue(defaults[i - firstdefault])
             specs.append(spec)
-    if varkw is not None:
-        specs.append(formatvarkw(formatargandannotation(varkw)))
-    result = '(' + ', '.join(specs) + ')'
-    if 'return' in annotations:
-        result += formatreturns(formatannotation(annotations['return']))
-    return result
+        if varargs is not None:
+            specs.append(formatvarargs(formatargandannotation(varargs)))
+        else:
+            if kwonlyargs:
+                specs.append('*')
+        if kwonlyargs:
+            for kwonlyarg in kwonlyargs:
+                spec = formatargandannotation(kwonlyarg)
+                if kwonlydefaults and kwonlyarg in kwonlydefaults:
+                    spec += formatvalue(kwonlydefaults[kwonlyarg])
+                specs.append(spec)
+        if varkw is not None:
+            specs.append(formatvarkw(formatargandannotation(varkw)))
+        result = '(' + ', '.join(specs) + ')'
+        if 'return' in annotations:
+            result += formatreturns(formatannotation(annotations['return']))
+        return result
+
 # end funcutils.py

--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -519,13 +519,13 @@ class FunctionBuilder(object):
                 annotations = self.annotations
             else:
                 annotations = {}
-            return inspect.formatargspec(self.args,
-                                         self.varargs,
-                                         self.varkw,
-                                         [],
-                                         self.kwonlyargs,
-                                         {},
-                                         annotations)
+            return formatargspec(self.args,
+                                 self.varargs,
+                                 self.varkw,
+                                 [],
+                                 self.kwonlyargs,
+                                 {},
+                                 annotations)
 
         _KWONLY_MARKER = re.compile(r"""
         \*     # a star
@@ -542,14 +542,14 @@ class FunctionBuilder(object):
                                     for arg in self.kwonlyargs)
                 formatters['formatvalue'] = lambda value: '=' + value
 
-            sig = inspect.formatargspec(self.args,
-                                        self.varargs,
-                                        self.varkw,
-                                        [],
-                                        kwonly_pairs,
-                                        kwonly_pairs,
-                                        {},
-                                        **formatters)
+            sig = formatargspec(self.args,
+                                self.varargs,
+                                self.varkw,
+                                [],
+                                kwonly_pairs,
+                                kwonly_pairs,
+                                {},
+                                **formatters)
             sig = self._KWONLY_MARKER.sub('', sig)
             return sig[1:-1]
 
@@ -786,4 +786,55 @@ except ImportError:
                 setattr(cls, opname, opfunc)
         return cls
 
+
+def formatargspec(args, varargs=None, varkw=None, defaults=None,
+                  kwonlyargs=(), kwonlydefaults={}, annotations={},
+                  formatarg=str,
+                  formatvarargs=lambda name: '*' + name,
+                  formatvarkw=lambda name: '**' + name,
+                  formatvalue=lambda value: '=' + repr(value),
+                  formatreturns=lambda text: ' -> ' + text,
+                  formatannotation=inspect.formatannotation):
+    """Format an argument spec from the values returned by getfullargspec.
+
+    The first seven arguments are (args, varargs, varkw, defaults,
+    kwonlyargs, kwonlydefaults, annotations).  The other five arguments
+    are the corresponding optional formatting functions that are called to
+    turn names and values into strings.  The last argument is an optional
+    function to format the sequence of arguments.
+
+    Deprecated since Python 3.5: use the `signature` function and `Signature`
+    objects.
+    """
+
+    def formatargandannotation(arg):
+        result = formatarg(arg)
+        if arg in annotations:
+            result += ': ' + formatannotation(annotations[arg])
+        return result
+    specs = []
+    if defaults:
+        firstdefault = len(args) - len(defaults)
+    for i, arg in enumerate(args):
+        spec = formatargandannotation(arg)
+        if defaults and i >= firstdefault:
+            spec = spec + formatvalue(defaults[i - firstdefault])
+        specs.append(spec)
+    if varargs is not None:
+        specs.append(formatvarargs(formatargandannotation(varargs)))
+    else:
+        if kwonlyargs:
+            specs.append('*')
+    if kwonlyargs:
+        for kwonlyarg in kwonlyargs:
+            spec = formatargandannotation(kwonlyarg)
+            if kwonlydefaults and kwonlyarg in kwonlydefaults:
+                spec += formatvalue(kwonlydefaults[kwonlyarg])
+            specs.append(spec)
+    if varkw is not None:
+        specs.append(formatvarkw(formatargandannotation(varkw)))
+    result = '(' + ', '.join(specs) + ')'
+    if 'return' in annotations:
+        result += formatreturns(formatannotation(annotations['return']))
+    return result
 # end funcutils.py

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -271,3 +271,27 @@ def test_get_arg_names():
     assert 'test' in fb_example.args
     assert fb_example.get_arg_names() == ('req', 'test')
     assert fb_example.get_arg_names(only_required=True) == ('req',)
+
+
+@pytest.mark.parametrize(
+    "args, varargs, varkw, defaults, invocation_str, sig_str",
+    [
+        (["a", "b"], None, None, None, "a, b", "(a, b)"),
+        (None, "args", "kwargs", None, "*args, **kwargs", "(*args, **kwargs)"),
+        ("a", None, None, dict(a="a"), "a", "(a)"),
+    ],
+)
+def test_get_invocation_sig_str(
+    args, varargs, varkw, defaults, invocation_str, sig_str
+):
+    fb = FunctionBuilder(
+        name='return_five',
+        body='return 5',
+        args=args,
+        varargs=varargs,
+        varkw=varkw,
+        defaults=defaults
+    )
+
+    assert fb.get_invocation_str() == invocation_str
+    assert fb.get_sig_str() == sig_str

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -147,3 +147,43 @@ def test_FunctionBuilder_add_arg_kwonly():
     with pytest.raises(TypeError):
         assert better_func('positional')
     return
+
+
+@pytest.mark.parametrize(
+    "args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, invocation_str, sig_str",
+    [
+        (
+            None,
+            "args",
+            "kwargs",
+            None,
+            "a",
+            dict(a="a"),
+            "*args, a=a, **kwargs",
+            "(*args, a, **kwargs)",
+        )
+    ],
+)
+def test_get_invocation_sig_str(
+    args,
+    varargs,
+    varkw,
+    defaults,
+    kwonlyargs,
+    kwonlydefaults,
+    invocation_str,
+    sig_str,
+):
+    fb = FunctionBuilder(
+        name="return_five",
+        body="return 5",
+        args=args,
+        varargs=varargs,
+        varkw=varkw,
+        defaults=defaults,
+        kwonlyargs=kwonlyargs,
+        kwonlydefaults=kwonlydefaults,
+    )
+
+    assert fb.get_invocation_str() == invocation_str
+    assert fb.get_sig_str() == sig_str


### PR DESCRIPTION
>boltons/funcutils.py:528: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly

- [x] add some tests to prevent regressions
- [x] ~switch to signature~
- [x] inline formatargspec