### PR TITLE
Fixed doctests

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -163,7 +163,7 @@ class FilePerms(object):
         Here's an example that holds true on most systems:
 
         >>> import tempfile
-        >>> 'r' in FilePerms.from_path(tempfile.tempdir).user
+        >>> 'r' in FilePerms.from_path(tempfile.gettempdir()).user
         True
         """
         stat_res = os.stat(path)

--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -583,12 +583,12 @@ class Stats(object):
         allowing for simple visualization, even in console environments.
 
         >>> data = list(range(20)) + list(range(5, 15)) + [10]
-        >>> print(Stats(data).format_histogram())
-         0.0:  5 ################################
-         4.4:  8 ###################################################
-         8.9: 11 ######################################################################
-        13.3:  5 ################################
-        17.8:  2 #############
+        >>> print(Stats(data).format_histogram(width=30))
+         0.0:  5 #########
+         4.4:  8 ###############
+         8.9: 11 ####################
+        13.3:  5 #########
+        17.8:  2 ####
 
         In this histogram, five values are between 0.0 and 4.4, eight
         are between 4.4 and 8.9, and two values lie between 17.8 and

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -1021,7 +1021,7 @@ class OrderedMultiDict(dict):
     >>> from pprint import pprint as pp  # ensuring proper key ordering
     >>> omd = OrderedMultiDict([('a', 1), ('b', 2), ('a', 3)])
     >>> pp(dict(omd))
-    {'a': 3, '': 2}
+    {'a': 3, 'b': 2}
 
     Note that modifying those lists will modify the OMD. If you want a
     safe-to-modify or flat dictionary, use :meth:`OrderedMultiDict.todict()`.

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -1021,7 +1021,7 @@ class OrderedMultiDict(dict):
     >>> from pprint import pprint as pp  # ensuring proper key ordering
     >>> omd = OrderedMultiDict([('a', 1), ('b', 2), ('a', 3)])
     >>> pp(dict(omd))
-    {'a': [1, 3], 'b': [2]}
+    {'a': 3, '': 2}
 
     Note that modifying those lists will modify the OMD. If you want a
     safe-to-modify or flat dictionary, use :meth:`OrderedMultiDict.todict()`.
@@ -1377,7 +1377,7 @@ class OrderedMultiDict(dict):
 
         >>> omd = OrderedMultiDict(zip('hello', 'world'))
         >>> omd.sorted(key=lambda i: i[1])  # i[0] is the key, i[1] is the val
-        OrderedMultiDict([('o', 'd'), ('l', 'l'), ('e', 'o'), ('h', 'w')])
+        OrderedMultiDict([('o', 'd'), ('l', 'l'), ('e', 'o'), ('l', 'r'), ('h', 'w')])
         """
         cls = self.__class__
         return cls(sorted(self.iteritems(), key=key, reverse=reverse))


### PR DESCRIPTION
Hi, 

I fixed 4 of bolton's doctests that were broken. For whatever reason, doctest wasn't running them. I'm exactly not sure why pytest + doctest didn't catch these errors, but the stdlib `doctests` is weird, so I don't question it. 

I caught these errors using [xdoctest](https://github.com/Erotemic/xdoctest), (its a module I wrote to improve upon and hopefully replace the builtin doctest). Because xdoctest uses a abstract-syntax-trees instead of regular expressions to "parse" doctests, xdoctest is able to handle parsing real context free expressions, which regex simply cannot do.

In fact doctest was only running 132 of the 137 doctests run via xdoctest. 

I understand this lib wants 0 external deps, but if you used xdoctest as a testing requirement, you could easilly run these tests on the CI. I believe this project uses pytest, so I imagine a testing dependency is not out of the question. Running `pip install xdoctest` installs the core module, the standalone executable, and a pytest plugin. By default it is non-intrusive and does nothing, to enable the pytest plugin run with --xdoctest-modules instead of --doctest-modules. Then you will see 137 tests run instead of 132. 

Note that if you decide to go with xdoctest, please wait until the 0.9.2 release. I had to make a minor rework to the parser to make two fixes for backwards compatibility.  (Strange how I found errors in my lib by looking for errors in yours. FOSS can be nice like this)

For now this is just a minor patch that ensures users wont looks at these examples and get different results. 

--- 
EDIT; 
Not sure why pypy and 2.6 are failing. It seems to be network related. 