### PR TITLE
Fix minor docstring formatting issues

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -480,8 +480,9 @@ def bucketize(src, key=bool, value_transform=None, key_filter=None):
     >>> bucketize(range(5), is_odd)
     {False: [0, 2, 4], True: [1, 3]}
 
-    *key* is :class bool: by default, but can either be a callable or a string
+    *key* is :class:`bool` by default, but can either be a callable or a string
     name of the attribute on which to bucketize objects.
+
     >>> bucketize([1+1j, 2+2j, 1, 2], key='real')
     {1.0: [(1+1j), 1], 2.0: [(2+2j), 2]}
 

--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -473,15 +473,14 @@ def complement(wrapped):
     way to invert an expression, you can just throw a complement on
     the set. Consider this example of a name filter::
 
-    >>> class NamesFilter(object):
-    ...    def __init__(self, allowed):
-    ...        self._allowed = allowed
-    ...
-    ...    def filter(self, names):
-    ...        return [name for name in names if name in self._allowed]
-
-    >>> NamesFilter(set(['alice', 'bob'])).filter(['alice', 'bob', 'carol'])
-    ['alice', 'bob']
+        >>> class NamesFilter(object):
+        ...    def __init__(self, allowed):
+        ...        self._allowed = allowed
+        ...
+        ...    def filter(self, names):
+        ...        return [name for name in names if name in self._allowed]
+        >>> NamesFilter(set(['alice', 'bob'])).filter(['alice', 'bob', 'carol'])
+        ['alice', 'bob']
 
     What if we want to just express "let all the names through"?
 


### PR DESCRIPTION
Fixes include:
* `itertools.bucketize`:
  * Annotate `bool` reference
  * Display `key=` usage example as code block
* `setutils.complement`:
  * Display entire `NamesFilter` example as code block
  * Remove backticks from bad `NamesFilter` usage example