### PR TITLE
cmdutils and flatapi

### DIFF
--- a/boltons/__init__.py
+++ b/boltons/__init__.py
@@ -1,0 +1,109 @@
+"""
+mkinit ~/code/boltons/boltons/__init__.py
+"""
+# flake8: noqa
+
+import os
+
+__version__ = '19.3.1dev'
+
+
+def enable_flat_api():
+    from boltons.cacheutils import (CachedFunction, CachedMethod, DEFAULT_MAX_SIZE,
+                                    LRI, LRU, MinIDMap, ThresholdCounter, cached,
+                                    cachedmethod, cachedproperty, make_cache_key,)
+    from boltons.cmdutils import (cmd,)
+    from boltons.debugutils import (pdb_on_exception, pdb_on_signal, wrap_trace,)
+    from boltons.deprutils import (DeprecatableModule, ModuleType,
+                                   deprecate_module_member,)
+    from boltons.dictutils import (FrozenDict, ManyToMany, MultiDict, OMD,
+                                   OneToOne, OrderedMultiDict, subdict,)
+    from boltons.easterutils import (gobs_program,)
+    from boltons.ecoutils import (CPU_COUNT, ECO_VERSION, EXPAT_VERSION, HAVE_IPV6,
+                                  HAVE_READLINE, HAVE_THREADING, HAVE_UCS4,
+                                  HAVE_URANDOM, INSTANCE_ID, IS_64BIT,
+                                  OPENSSL_VERSION, PY_GT_2, SQLITE_VERSION,
+                                  START_TIME_INFO, TKINTER_VERSION, ZLIB_VERSION,
+                                  get_profile, get_profile_json, get_python_info,
+                                  getrandbits, main,)
+    from boltons.excutils import (ExceptionCauseMixin,)
+    from boltons.fileutils import (AtomicSaver, FilePerms, atomic_save, copytree,
+                                   iter_find_files, mkdir_p,)
+    from boltons.formatutils import (BaseFormatField, DeferredValue,
+                                     construct_format_field_str, get_format_args,
+                                     infer_positional_format_args,
+                                     tokenize_format_str,)
+    from boltons.funcutils import (CachedInstancePartial, ExistingArgument,
+                                   FunctionBuilder, InstancePartial,
+                                   MissingArgument, NO_DEFAULT, copy_function,
+                                   dir_dict, format_exp_repr, format_invocation,
+                                   format_nonexp_repr, get_module_callables,
+                                   make_method, mro_items, partial,
+                                   partial_ordering, wraps,)
+    from boltons.gcutils import (GCToggler, get_all, toggle_gc,
+                                 toggle_gc_postcollect,)
+    from boltons.ioutils import (MultiFileReader, READ_CHUNK_SIZE, SpooledBytesIO,
+                                 SpooledIOBase, SpooledStringIO, binary_type,
+                                 is_text_fileobj, text_type,)
+    from boltons.iterutils import (GUIDerator, PathAccessError,
+                                   SequentialGUIDerator, backoff, backoff_iter,
+                                   bucketize, chunked, chunked_iter, default_enter,
+                                   default_exit, default_visit, first, flatten,
+                                   flatten_iter, frange, get_path, guid_iter,
+                                   is_collection, is_iterable, is_scalar, one,
+                                   pairwise, pairwise_iter, partition, redundant,
+                                   remap, research, same, seq_guid_iter,
+                                   soft_sorted, split, split_iter, unique,
+                                   unique_iter, windowed, windowed_iter, xfrange,)
+    from boltons.jsonutils import (JSONLIterator, reverse_iter_lines,)
+    from boltons.listutils import (BList, BarrelList,)
+    from boltons.mathutils import (Bits, ceil, clamp, floor,)
+    from boltons.mboxutils import (DEFAULT_MAXMEM, mbox_readonlydir,)
+    from boltons.namedutils import (namedlist, namedtuple,)
+    from boltons.queueutils import (BasePriorityQueue, HeapPriorityQueue,
+                                    PriorityQueue, SortedPriorityQueue,)
+    from boltons.setutils import (IndexedSet, complement,)
+    from boltons.socketutils import (BufferedSocket, ConnectionClosed,
+                                     DEFAULT_MAXSIZE, DEFAULT_TIMEOUT, Error,
+                                     MessageTooLong, NetstringInvalidSize,
+                                     NetstringMessageTooLong,
+                                     NetstringProtocolError, NetstringSocket,
+                                     Timeout,)
+    from boltons.statsutils import (Stats, describe, format_histogram_counts,)
+    from boltons.strutils import (a10n, args2cmd, args2sh, asciify, bytes2human,
+                                  camel2under, cardinalize, escape_shell_args,
+                                  find_hashtags, format_int_list, gunzip_bytes,
+                                  gzip_bytes, html2text, indent, is_ascii, is_uuid,
+                                  iter_splitlines, ordinalize, parse_int_list,
+                                  pluralize, singularize, slugify, split_punct_ws,
+                                  strip_ansi, under2camel, unit_len,)
+    from boltons.tableutils import (Table,)
+    from boltons.tbutils import (Callpoint, ContextualCallpoint,
+                                 ContextualExceptionInfo, ContextualTracebackInfo,
+                                 ExceptionInfo, ParsedException, TracebackInfo,
+                                 print_exception,)
+    from boltons.timeutils import (Central, ConstantTZInfo, DSTEND_1967_1986,
+                                   DSTEND_1987_2006, DSTEND_2007,
+                                   DSTSTART_1967_1986, DSTSTART_1987_2006,
+                                   DSTSTART_2007, EPOCH_AWARE, EPOCH_NAIVE,
+                                   Eastern, HOUR, LocalTZ, LocalTZInfo, Mountain,
+                                   Pacific, USTimeZone, UTC, ZERO, daterange,
+                                   decimal_relative_time, dt_to_timestamp,
+                                   isoparse, parse_td, parse_timedelta,
+                                   relative_time, strpdate, total_seconds,)
+    from boltons.typeutils import (classproperty, get_all_subclasses,
+                                   make_sentinel,)
+    from boltons.urlutils import (DEFAULT_ENCODING, DEFAULT_PARSED_URL,
+                                  NO_NETLOC_SCHEMES, OMD, OrderedMultiDict,
+                                  QueryParamDict, SCHEME_PORT_MAP, URL,
+                                  URLParseError, cachedproperty, find_all_links,
+                                  parse_host, parse_qsl, parse_url,
+                                  quote_fragment_part, quote_path_part,
+                                  quote_query_part, quote_userinfo_part,
+                                  register_scheme, resolve_path_parts, to_unicode,
+                                  unicode, unquote, unquote_to_bytes,)
+
+
+FLATMODE = (os.environ.get('BOLTONS_FLATMODE', '') == 'TRUE')
+if FLATMODE:
+    enable_flat_api()

--- a/boltons/__init__.py
+++ b/boltons/__init__.py
@@ -8,7 +8,7 @@ import os
 __version__ = '19.3.1dev'
 
 
-def enable_flat_api():
+def enable_flatapi():
     from boltons.cacheutils import (CachedFunction, CachedMethod, DEFAULT_MAX_SIZE,
                                     LRI, LRU, MinIDMap, ThresholdCounter, cached,
                                     cachedmethod, cachedproperty, make_cache_key,)
@@ -102,8 +102,12 @@ def enable_flat_api():
                                   quote_query_part, quote_userinfo_part,
                                   register_scheme, resolve_path_parts, to_unicode,
                                   unicode, unquote, unquote_to_bytes,)
+    # EVERYTHING IS TOP LEVEL NOW
+    globals().update(**locals())
 
 
+import os
 FLATMODE = (os.environ.get('BOLTONS_FLATMODE', '') == 'TRUE')
+
 if FLATMODE:
-    enable_flat_api()
+    enable_flatapi()

--- a/boltons/__init__.py
+++ b/boltons/__init__.py
@@ -107,7 +107,6 @@ def enable_flatapi():
 
 
 import os
-FLATMODE = (os.environ.get('BOLTONS_FLATMODE', '') == 'TRUE')
-
-if FLATMODE:
+ENABLE_FLATAPI = (os.environ.get('BOLTONS_ENABLE_FLATAPI', '') == 'TRUE')
+if ENABLE_FLATAPI:
     enable_flatapi()

--- a/boltons/cmdutils.py
+++ b/boltons/cmdutils.py
@@ -374,3 +374,12 @@ def _shrinkuser(path, home='~'):
         elif path[len(userhome_dpath)] == os.path.sep:
             path = home + path[len(userhome_dpath):]
     return path
+
+
+if __name__ == '__main__':
+    """
+    CommandLine:
+        python ~/code/boltons/boltons/cmdutils.py
+    """
+    import xdoctest
+    xdoctest.doctest_module(__file__)

--- a/boltons/cmdutils.py
+++ b/boltons/cmdutils.py
@@ -1,0 +1,376 @@
+# -*- coding: utf-8 -*-
+r"""
+This module defines the :func:`cmd` command, which provides a simple means for
+interacting with the commandline. While this does use :class:`subprocess.Popen`
+under the hood, the key draw of :func:`cmd` is that you can capture
+stdout/stderr in your program while simultaneously printing it to the terminal
+in real time.
+
+Example:
+    >>> from boltons.cmdutils import cmd
+    >>> # Running with verbose=1 will write to stdout in real time
+    >>> info = cmd('echo "write your command naturally"', verbose=1)
+    write your command naturally
+    >>> # Unless `detatch=True`, `cmd` always returns an info dict.
+    >>> print('info = ' + repr(info))  # xdoctest: +IGNORE_WANT
+    info = {
+        'command': 'echo "write your command naturally"',
+        'cwd': None,
+        'err': '',
+        'out': 'write your command naturally\n',
+        'proc': <subprocess.Popen object at ...>,
+        'ret': 0,
+    }
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
+import six
+
+POSIX = 'posix' in sys.builtin_module_names
+
+if POSIX:
+    import select
+else:  # nocover
+    select = NotImplemented
+
+__all__ = ['cmd']
+
+
+def _textio_iterlines(stream):
+    """
+    Iterates over lines in a TextIO stream until an EOF is encountered.
+    This is the iterator version of stream.readlines()
+    """
+    line = stream.readline()
+    while line != '':
+        yield line
+        line = stream.readline()
+
+
+def _proc_async_iter_stream(proc, stream, buffersize=1):
+    """
+    Reads output from a process in a separate thread
+    """
+    from six.moves import queue
+    from threading import Thread
+    def enqueue_output(proc, stream, stream_queue):
+        while proc.poll() is None:
+            line = stream.readline()
+            # print('ENQUEUE LIVE {!r} {!r}'.format(stream, line))
+            stream_queue.put(line)
+
+        for line in _textio_iterlines(stream):
+            # print('ENQUEUE FINAL {!r} {!r}'.format(stream, line))
+            stream_queue.put(line)
+
+        # print("STREAM IS DONE {!r}".format(stream))
+        stream_queue.put(None)  # signal that the stream is finished
+        # stream.close()
+    stream_queue = queue.Queue(maxsize=buffersize)
+    _thread = Thread(target=enqueue_output, args=(proc, stream, stream_queue))
+    _thread.daemon = True  # thread dies with the program
+    _thread.start()
+    return stream_queue
+
+
+def _proc_iteroutput_thread(proc):
+    """
+    Iterates over output from a process line by line
+
+    Note:
+        WARNING. Current implementation might have bugs with other threads.
+        This behavior was seen when using earlier versions of tqdm. I'm not
+        sure if this was our bug or tqdm's. Newer versions of tqdm fix this,
+        but I cannot guarantee that there isn't an issue on our end.
+
+    Yields:
+        Tuple[str, str]: oline, eline: stdout and stderr line
+
+    References:
+        https://stackoverflow.com/questions/375427/non-blocking-read-subproc
+    """
+    from six.moves import queue
+
+    # Create threads that read stdout / stderr and queue up the output
+    stdout_queue = _proc_async_iter_stream(proc, proc.stdout)
+    stderr_queue = _proc_async_iter_stream(proc, proc.stderr)
+
+    stdout_live = True
+    stderr_live = True
+
+    # read from the output asynchronously until
+    while stdout_live or stderr_live:
+        if stdout_live:  # pragma: nobranch
+            try:
+                oline = stdout_queue.get_nowait()
+                stdout_live = oline is not None
+            except queue.Empty:
+                oline = None
+        if stderr_live:
+            try:
+                eline = stderr_queue.get_nowait()
+                stderr_live = eline is not None
+            except queue.Empty:
+                eline = None
+        if oline is not None or eline is not None:
+            yield oline, eline
+
+
+def _proc_iteroutput_select(proc):
+    """
+    Iterates over output from a process line by line
+
+    UNIX only. Use :func:`_proc_iteroutput_thread` instead for a cross platform
+    solution based on threads.
+
+    Yields:
+        Tuple[str, str]: oline, eline: stdout and stderr line
+    """
+    from six.moves import zip_longest
+    # Read output while the external program is running
+    while proc.poll() is None:
+        reads = [proc.stdout.fileno(), proc.stderr.fileno()]
+        ret = select.select(reads, [], [])
+        oline = eline = None
+        for fd in ret[0]:
+            if fd == proc.stdout.fileno():
+                oline = proc.stdout.readline()
+            if fd == proc.stderr.fileno():
+                eline = proc.stderr.readline()
+        yield oline, eline
+
+    # Grab any remaining data in stdout and stderr after the process finishes
+    oline_iter = _textio_iterlines(proc.stdout)
+    eline_iter = _textio_iterlines(proc.stderr)
+    for oline, eline in zip_longest(oline_iter, eline_iter):
+        yield oline, eline
+
+
+def _tee_output(proc, stdout=None, stderr=None, backend='auto'):
+    """
+    Simultaneously reports and captures stdout and stderr from a process
+
+    subprocess must be created using (stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE)
+    """
+    logged_out = []
+    logged_err = []
+    if backend == 'auto':
+        # backend = 'select' if POSIX else 'thread'
+        backend = 'thread'
+
+    if backend == 'select':
+        if not POSIX:  # nocover
+            raise NotImplementedError('select is only available on posix')
+        # the select-based version is stable, but slow
+        _proc_iteroutput = _proc_iteroutput_select
+    elif backend == 'thread':
+        # the thread version is fast, but might run into issues.
+        _proc_iteroutput = _proc_iteroutput_thread
+    else:
+        raise ValueError('backend must be select, thread, or auto')
+
+    for oline, eline in _proc_iteroutput(proc):
+        if oline:
+            if stdout:  # pragma: nobranch
+                stdout.write(oline)
+                stdout.flush()
+            logged_out.append(oline)
+        if eline:
+            if stderr:  # pragma: nobranch
+                stderr.write(eline)
+                stderr.flush()
+            logged_err.append(eline)
+    return proc, logged_out, logged_err
+
+
+def cmd(command, shell=False, detach=False, verbose=0, tee=None, cwd=None,
+        env=None, tee_backend='auto'):
+    """
+    Executes a command in a subprocess.
+
+    The advantage of this wrapper around subprocess is that
+    (1) you control if the subprocess prints to stdout,
+    (2) the text written to stdout and stderr is returned for parsing,
+    (3) cross platform behavior that lets you specify the command as a string
+    or tuple regardless of whether or not shell=True.
+    (4) ability to detach, return the process object and allow the process to
+    run in the background (eventually we may return a Future object instead).
+
+    Args:
+        command (str or Sequence): bash-like command string or tuple of
+            executable and args
+
+        shell (bool, default=False): if True, process is run in shell.
+
+        detach (bool, default=False):
+            if True, process is detached and run in background.
+
+        verbose (int, default=0): verbosity mode. Can be 0, 1, 2, or 3.
+
+        tee (bool, optional): if True, simultaneously writes to stdout while
+            capturing output from the command. If not specified, defaults to
+            True if verbose > 0.  If detach is True, then this argument is
+            ignored.
+
+        cwd (PathLike, optional): path to run command
+
+        env (str, optional): environment passed to Popen
+
+        tee_backend (str, optional): backend for tee output.
+            Valid choices are: "auto", "select" (POSIX only), and "thread".
+
+        **kwargs: only used to support deprecated arguments
+
+    Returns:
+        dict: info - information about command status.
+            if detach is False ``info`` contains captured standard out,
+            standard error, and the return code
+            if detach is False ``info`` contains a reference to the process.
+
+    Notes:
+        Inputs can either be text or tuple based. On UNIX we ensure conversion
+        to text if shell=True, and to tuple if shell=False. On windows, the
+        input is always text based.  See [3]_ for a potential cross-platform
+        shlex solution for windows.
+
+    References:
+        .. [1] https://stackoverflow.com/questions/11495783/redirect-subprocess-stderr-to-stdout
+        .. [2] https://stackoverflow.com/questions/7729336/how-can-i-print-and-display-subprocess-stdout-and-stderr-output-without-distorti
+        .. [3] https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex
+
+    Example:
+        >>> info = cmd(('echo', 'simple cmdline interface'), verbose=1)
+        simple cmdline interface
+        >>> assert info['ret'] == 0
+        >>> assert info['out'].strip() == 'simple cmdline interface'
+        >>> assert info['err'].strip() == ''
+
+    Example:
+        >>> info = cmd('echo str noshell', verbose=0)
+        >>> assert info['out'].strip() == 'str noshell'
+
+    Example:
+        >>> # windows echo will output extra single quotes
+        >>> info = cmd(('echo', 'tuple noshell'), verbose=0)
+        >>> assert info['out'].strip().strip("'") == 'tuple noshell'
+
+    Example:
+        >>> # Note this command is formatted to work on win32 and unix
+        >>> info = cmd('echo str&&echo shell', verbose=0, shell=True)
+        >>> assert info['out'].strip() == 'str' + chr(10) + 'shell'
+
+    Example:
+        >>> info = cmd(('echo', 'tuple shell'), verbose=0, shell=True)
+        >>> assert info['out'].strip().strip("'") == 'tuple shell'
+    """
+    # Determine if command is specified as text or a tuple
+    if isinstance(command, six.string_types):
+        command_text = command
+        command_tup = None
+    else:
+        import pipes
+        command_tup = command
+        command_text = ' '.join(list(map(pipes.quote, command_tup)))
+
+    if shell or sys.platform.startswith('win32'):
+        # When shell=True, args is sent to the shell (e.g. bin/sh) as text
+        args = command_text
+    else:
+        # When shell=False, args is a list of executable and arguments
+        if command_tup is None:
+            # parse this out of the string
+            # NOTE: perhaps use the solution from [3] here?
+            import shlex
+            command_tup = shlex.split(command_text)
+            # command_tup = shlex.split(command_text, posix=not WIN32)
+        args = command_tup
+
+    if tee is None:
+        tee = verbose > 0
+    if verbose > 1:
+        import os
+        import platform
+        import getpass
+        if verbose > 2:
+            try:
+                print('┌─── START CMD ───')
+            except Exception:  # nocover
+                print('+=== START CMD ===')
+        cwd_ = os.getcwd() if cwd is None else cwd
+        compname = platform.node()
+        username = getpass.getuser()
+
+        cwd_ = _shrinkuser(cwd_)
+        ps1 = '[cmd] {}@{}:{}$ '.format(username, compname, cwd_)
+        print(ps1 + command_text)
+
+    # Create a new process to execute the command
+    def make_proc():
+        # delay the creation of the process until we validate all args
+        import subprocess
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, shell=shell,
+                                universal_newlines=True, cwd=cwd, env=env)
+        return proc
+
+    if detach:
+        info = {'proc': make_proc(), 'command': command_text}
+        if verbose > 0:  # nocover
+            print('...detaching')
+    else:
+        if tee:
+            # We logging stdout and stderr, while simulaniously piping it to
+            # another stream.
+            stdout = sys.stdout
+            stderr = sys.stderr
+            proc = make_proc()
+            proc, logged_out, logged_err = _tee_output(proc, stdout, stderr,
+                                                       backend=tee_backend)
+
+            try:
+                out = ''.join(logged_out)
+            except UnicodeDecodeError:  # nocover
+                out = '\n'.join(_.decode('utf-8') for _ in logged_out)
+            try:
+                err = ''.join(logged_err)
+            except UnicodeDecodeError:  # nocover
+                err = '\n'.join(_.decode('utf-8') for _ in logged_err)
+            (out_, err_) = proc.communicate()
+        else:
+            proc = make_proc()
+            (out, err) = proc.communicate()
+        # calling wait means that the process will terminate and it is safe to
+        # return a reference to the process object.
+        ret = proc.wait()
+        info = {
+            'out': out,
+            'err': err,
+            'ret': ret,
+            'proc': proc,
+            'cwd': cwd,
+            'command': command_text
+        }
+        if verbose > 2:
+            # https://en.wikipedia.org/wiki/Box-drawing_character
+            try:
+                print('└─── END CMD ───')
+            except Exception:  # nocover
+                print('L___ END CMD ___')
+    return info
+
+
+def _shrinkuser(path, home='~'):
+    """
+    Internal version of :func:`boltons.pathutils.strinkuser'
+    """
+    from os.path import expanduser, normpath
+    import os
+    path = normpath(path)
+    userhome_dpath = expanduser('~')
+    if path.startswith(userhome_dpath):
+        if len(path) == len(userhome_dpath):
+            path = home
+        elif path[len(userhome_dpath)] == os.path.sep:
+            path = home + path[len(userhome_dpath):]
+    return path

--- a/tests/test_cmdutils.py
+++ b/tests/test_cmdutils.py
@@ -1,0 +1,527 @@
+# -*- coding: utf-8 -*-
+"""
+
+xdoctest -m netharn.export.closer _closefile --fpath=$HOME/code/boltons/tests/test_cmdutils.py --modnames=ubelt,
+
+"""
+import pytest
+import sys
+import io
+import six
+from os.path import join
+from os.path import expanduser
+from os.path import normpath
+import os
+from boltons.cmdutils import cmd
+
+
+WIN32 = (sys.platform == 'win32')
+LINUX = sys.platform.startswith('linux')
+DARWIN = (sys.platform == 'darwin')
+
+
+def platform_cache_dir():
+    """
+    Returns a directory which should be writable for any application
+    This should be used for temporary deletable data.
+
+    Returns:
+        str : path to the cache dir used by the current operating system
+    """
+    if LINUX:  # nocover
+        dpath_ = os.environ.get('XDG_CACHE_HOME', '~/.cache')
+    elif DARWIN:  # nocover
+        dpath_  = '~/Library/Caches'
+    elif WIN32:  # nocover
+        dpath_ = os.environ.get('LOCALAPPDATA', '~/AppData/Local')
+    else:  # nocover
+        raise NotImplementedError('Unknown Platform  %r' % (sys.platform,))
+    dpath = normpath(expanduser(dpath_))
+    return dpath
+
+
+def get_app_cache_dir(appname, *args):
+    r"""
+    Returns a writable directory for an application.
+    This should be used for temporary deletable data.
+
+    Args:
+        appname (str): the name of the application
+        *args: any other subdirectories may be specified
+
+    Returns:
+        str : dpath: writable cache directory for this application
+
+    SeeAlso:
+        ensure_app_cache_dir
+    """
+    dpath = join(platform_cache_dir(), appname, *args)
+    return dpath
+
+
+def ensure_app_cache_dir(appname, *args):
+    """
+    Calls :func:`get_app_cache_dir` but ensures the directory exists.
+
+    Args:
+        appname (str): the name of the application
+        *args: any other subdirectories may be specified
+
+    SeeAlso:
+        get_app_cache_dir
+
+    Example:
+        >>> dpath = ensure_app_cache_dir('boltons')
+        >>> assert exists(dpath)
+    """
+    dpath = get_app_cache_dir(appname, *args)
+    from boltons import fileutils
+    fileutils.mkdir_p(dpath)
+    return dpath
+
+
+def ensure_app_resource_dir(appname, *args):  # nocover
+    """
+    Calls `get_app_resource_dir` but ensures the directory exists.
+
+    DEPRICATED in favor of ensure_app_config_dir / ensure_app_data_dir
+
+    Args:
+        appname (str): the name of the application
+        *args: any other subdirectories may be specified
+
+    SeeAlso:
+        get_app_resource_dir
+    """
+    return ensure_app_cache_dir(appname, *args)
+
+
+def codeblock(block_str):
+    """
+    Create a block of text that preserves all newlines and relative indentation
+
+    Wraps multiline string blocks and returns unindented code.
+    Useful for templated code defined in indented parts of code.
+
+    Args:
+        block_str (str): typically in the form of a multiline string
+
+    Returns:
+        str: the unindented string
+
+    Example:
+        >>> # Simulate an indented part of code
+        >>> if True:
+        >>>     # notice the indentation on this will be normal
+        >>>     codeblock_version = codeblock(
+        ...             '''
+        ...             def foo():
+        ...                 return 'bar'
+        ...             '''
+        ...         )
+        >>>     # notice the indentation and newlines on this will be odd
+        >>>     normal_version = ('''
+        ...         def foo():
+        ...             return 'bar'
+        ...     ''')
+        >>> assert normal_version != codeblock_version
+        >>> print('Without codeblock')
+        >>> print(normal_version)
+        >>> print('With codeblock')
+        >>> print(codeblock_version)
+    """
+    import textwrap  # this is a slow import, do it lazy
+    return textwrap.dedent(block_str).strip('\n')
+
+
+class TeeStringIO(io.StringIO):
+    """
+    An IO object that writes to itself and another IO stream.
+
+    Attributes:
+        redirect (io.IOBase): The other stream to write to.
+
+    Example:
+        >>> redirect = io.StringIO()
+        >>> self = TeeStringIO(redirect)
+    """
+    def __init__(self, redirect=None):
+        self.redirect = redirect
+        super(TeeStringIO, self).__init__()
+
+    def isatty(self):  # nocover
+        """
+        Returns true of the redirect is a terminal.
+
+        Notes:
+            Needed for IPython.embed to work properly when this class is used
+            to override stdout / stderr.
+        """
+        return (self.redirect is not None and
+                hasattr(self.redirect, 'isatty') and self.redirect.isatty())
+
+    @property
+    def encoding(self):
+        """
+        Gets the encoding of the `redirect` IO object
+
+        Example:
+            >>> redirect = io.StringIO()
+            >>> assert TeeStringIO(redirect).encoding is None
+            >>> assert TeeStringIO(None).encoding is None
+            >>> assert TeeStringIO(sys.stdout).encoding is sys.stdout.encoding
+            >>> redirect = io.TextIOWrapper(io.StringIO())
+            >>> assert TeeStringIO(redirect).encoding is redirect.encoding
+        """
+        if self.redirect is not None:
+            return self.redirect.encoding
+        else:
+            return super(TeeStringIO, self).encoding
+
+    def write(self, msg):
+        """
+        Write to this and the redirected stream
+        """
+        if self.redirect is not None:
+            self.redirect.write(msg)
+        if six.PY2:
+            from xdoctest.utils.util_str import ensure_unicode
+            msg = ensure_unicode(msg)
+        super(TeeStringIO, self).write(msg)
+
+    def flush(self):  # nocover
+        """
+        Flush to this and the redirected stream
+        """
+        if self.redirect is not None:
+            self.redirect.flush()
+        super(TeeStringIO, self).flush()
+
+
+class CaptureStream(object):
+    """
+    Generic class for capturing streaming output from stdout or stderr
+    """
+
+
+class CaptureStdout(CaptureStream):
+    r"""
+    Context manager that captures stdout and stores it in an internal stream
+
+    Args:
+        supress (bool, default=True):
+            if True, stdout is not printed while captured
+        enabled (bool, default=True):
+            does nothing if this is False
+
+    Example:
+        >>> self = CaptureStdout(supress=True)
+        >>> print('dont capture the table flip (╯°□°）╯︵ ┻━┻')
+        >>> with self:
+        ...     text = 'capture the heart ♥'
+        ...     print(text)
+        >>> print('dont capture look of disapproval ಠ_ಠ')
+        >>> assert isinstance(self.text, six.text_type)
+        >>> assert self.text == text + '\n', 'failed capture text'
+
+    Example:
+        >>> self = CaptureStdout(supress=False)
+        >>> with self:
+        ...     print('I am captured and printed in stdout')
+        >>> assert self.text.strip() == 'I am captured and printed in stdout'
+
+    Example:
+        >>> self = CaptureStdout(supress=True, enabled=False)
+        >>> with self:
+        ...     print('dont capture')
+        >>> assert self.text is None
+    """
+    def __init__(self, supress=True, enabled=True):
+        self.enabled = enabled
+        self.supress = supress
+        self.orig_stdout = sys.stdout
+        if supress:
+            redirect = None
+        else:
+            redirect = self.orig_stdout
+        self.cap_stdout = TeeStringIO(redirect)
+        self.text = None
+
+        self._pos = 0  # keep track of how much has been logged
+        self.parts = []
+        self.started = False
+
+    def log_part(self):
+        """ Log what has been captured so far """
+        self.cap_stdout.seek(self._pos)
+        text = self.cap_stdout.read()
+        self._pos = self.cap_stdout.tell()
+        self.parts.append(text)
+        self.text = text
+
+    def start(self):
+        if self.enabled:
+            self.text = ''
+            self.started = True
+            sys.stdout = self.cap_stdout
+
+    def stop(self):
+        """
+        Example:
+            >>> CaptureStdout(enabled=False).stop()
+            >>> CaptureStdout(enabled=True).stop()
+        """
+        if self.enabled:
+            self.started = False
+            sys.stdout = self.orig_stdout
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __del__(self):  # nocover
+        if self.started:
+            self.stop()
+        if self.cap_stdout is not None:
+            self.close()
+
+    def close(self):
+        self.cap_stdout.close()
+        self.cap_stdout = None
+
+    def __exit__(self, type_, value, trace):
+        if self.enabled:
+            try:
+                self.log_part()
+            except Exception:  # nocover
+                raise
+            finally:
+                self.stop()
+        if trace is not None:
+            return False  # return a falsey value on error
+
+
+def test_cmd_stdout():
+    with CaptureStdout() as cap:
+        result = cmd('echo hello stdout', verbose=True)
+    assert result['out'].strip() == 'hello stdout'
+    assert cap.text.strip() == 'hello stdout'
+
+
+def test_cmd_veryverbose():
+    with CaptureStdout() as cap:
+        result = cmd('echo hello stdout', verbose=3)
+    assert result['out'].strip() == 'hello stdout'
+    print(cap.text)
+    # assert cap.text.strip() == 'hello stdout'
+
+
+def test_tee_false():
+    with CaptureStdout() as cap:
+        result = cmd('echo hello stdout', verbose=3, tee=False)
+    assert result['out'].strip() == 'hello stdout'
+    assert 'hello world' not in cap.text
+    print(cap.text)
+
+
+def test_cmd_stdout_quiet():
+    with CaptureStdout() as cap:
+        result = cmd('echo hello stdout', verbose=False)
+    assert result['out'].strip() == 'hello stdout', 'should still capture internally'
+    assert cap.text.strip() == '', 'nothing should print to stdout'
+
+
+def test_cmd_stderr():
+    result = cmd('echo hello stderr 1>&2', shell=True, verbose=True)
+    assert result['err'].strip() == 'hello stderr'
+
+
+def test_cmd_tee_auto():
+    """
+    pytest ubelt/tests/test_cmd.py -k tee_backend
+    pytest ubelt/tests/test_cmd.py
+    """
+    command = 'python -c "for i in range(100): print(str(i))"'
+    result = cmd(command, verbose=0, tee_backend='auto')
+    assert result['out'] == '\n'.join(list(map(str, range(100)))) + '\n'
+
+
+def test_cmd_tee_thread():
+    """
+    CommandLine:
+        pytest ubelt/tests/test_cmd.py::test_cmd_tee_thread -s
+        python ubelt/tests/test_cmd.py test_cmd_tee_thread
+    """
+    if 'tqdm' in sys.modules:
+        if tuple(map(int, sys.modules['tqdm'].__version__.split('.'))) < (4, 19):
+            pytest.skip(reason='threads cause issues with early tqdms')
+
+    import threading
+    # check which threads currently exist (ideally 1)
+    existing_threads = list(threading.enumerate())
+    print('existing_threads = {!r}'.format(existing_threads))
+
+    command = 'python -c "for i in range(10): print(str(i))"'
+    result = cmd(command, verbose=0, tee_backend='thread')
+    assert result['out'] == '\n'.join(list(map(str, range(10)))) + '\n'
+
+    after_threads = list(threading.enumerate())
+    print('after_threads = {!r}'.format(after_threads))
+    assert len(existing_threads) <= len(after_threads), (
+        'we should be cleaning up our threads')
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='not available on win32')
+def test_cmd_tee_select():
+    command = 'python -c "for i in range(100): print(str(i))"'
+    result = cmd(command, verbose=1, tee_backend='select')
+    assert result['out'] == '\n'.join(list(map(str, range(100)))) + '\n'
+
+    command = 'python -c "for i in range(100): print(str(i))"'
+    result = cmd(command, verbose=0, tee_backend='select')
+    assert result['out'] == '\n'.join(list(map(str, range(100)))) + '\n'
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='not available on win32')
+def test_cmd_tee_badmethod():
+    """
+    pytest ubelt/tests/test_cmd.py::test_cmd_tee_badmethod
+    """
+    command = 'python -c "for i in range(100): print(str(i))"'
+    with pytest.raises(ValueError):
+        cmd(command, verbose=2, tee_backend='bad tee backend')
+
+
+def test_cmd_multiline_stdout():
+    """
+    python ubelt/tests/test_cmd.py test_cmd_multiline_stdout
+    pytest ubelt/tests/test_cmd.py::test_cmd_multiline_stdout
+    """
+    command = 'python -c "for i in range(10): print(str(i))"'
+    result = cmd(command, verbose=0)
+    assert result['out'] == '\n'.join(list(map(str, range(10)))) + '\n'
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='does not run on win32')
+def test_cmd_interleaved_streams_sh():
+    """
+    A test that ``Crosses the Streams'' of stdout and stderr
+
+    pytest ubelt/tests/test_cmd.py::test_cmd_interleaved_streams_sh
+    """
+    if False:
+        sh_script = codeblock(
+            r'''
+            for i in `seq 0 29`;
+            do
+                sleep .001
+                >&1 echo "O$i"
+                if [ "$(($i % 5))" = "0" ]; then
+                    >&2 echo "!E$i"
+                fi
+            done
+            ''').lstrip()
+        result = cmd(sh_script, shell=True, verbose=0)
+
+        assert result['out'] == 'O0\nO1\nO2\nO3\nO4\nO5\nO6\nO7\nO8\nO9\nO10\nO11\nO12\nO13\nO14\nO15\nO16\nO17\nO18\nO19\nO20\nO21\nO22\nO23\nO24\nO25\nO26\nO27\nO28\nO29\n'
+        assert result['err'] == '!E0\n!E5\n!E10\n!E15\n!E20\n!E25\n'
+    else:
+        sh_script = codeblock(
+            r'''
+            for i in `seq 0 15`;
+            do
+                sleep .000001
+                >&1 echo "O$i"
+                if [ "$(($i % 5))" = "0" ]; then
+                    >&2 echo "!E$i"
+                fi
+            done
+            ''').lstrip()
+        result = cmd(sh_script, shell=True, verbose=0)
+
+        assert result['out'] == 'O0\nO1\nO2\nO3\nO4\nO5\nO6\nO7\nO8\nO9\nO10\nO11\nO12\nO13\nO14\nO15\n'
+        assert result['err'] == '!E0\n!E5\n!E10\n!E15\n'
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='does not run on win32')
+def test_cmd_interleaved_streams_py():
+    # apparently multiline quotes dont work on win32
+    if False:
+        # slow mode
+        py_script = codeblock(
+            r'''
+            python -c "
+            import sys
+            import time
+            for i in range(30):
+                time.sleep(.001)
+                sys.stdout.write('O{}\n'.format(i))
+                sys.stdout.flush()
+                if i % 5 == 0:
+                    sys.stderr.write('!E{}\n'.format(i))
+                    sys.stderr.flush()
+            "
+            ''').lstrip()
+        result = cmd(py_script, verbose=0)
+
+        assert result['out'] == 'O0\nO1\nO2\nO3\nO4\nO5\nO6\nO7\nO8\nO9\nO10\nO11\nO12\nO13\nO14\nO15\nO16\nO17\nO18\nO19\nO20\nO21\nO22\nO23\nO24\nO25\nO26\nO27\nO28\nO29\n'
+        assert result['err'] == '!E0\n!E5\n!E10\n!E15\n!E20\n!E25\n'
+    else:
+        # faster mode
+        py_script = codeblock(
+            r'''
+            python -c "
+            import sys
+            import time
+            for i in range(15):
+                time.sleep(.000001)
+                sys.stdout.write('O{}\n'.format(i))
+                sys.stdout.flush()
+                if i % 5 == 0:
+                    sys.stderr.write('!E{}\n'.format(i))
+                    sys.stderr.flush()
+            "
+            ''').lstrip()
+        result = cmd(py_script, verbose=0)
+
+        assert result['out'] == 'O0\nO1\nO2\nO3\nO4\nO5\nO6\nO7\nO8\nO9\nO10\nO11\nO12\nO13\nO14\n'
+        assert result['err'] == '!E0\n!E5\n!E10\n'
+
+
+def test_cwd():
+    """
+    CommandLine:
+        python ~/code/ubelt/ubelt/tests/test_cmd.py test_cwd
+    """
+    import sys
+    import os
+    if not sys.platform.startswith('win32'):
+        dpath = ensure_app_resource_dir('ubelt')
+        dpath = os.path.realpath(dpath)
+        info = cmd('pwd', cwd=dpath, shell=True)
+        # print('info = {}'.format(repr2(info, nl=1)))
+        print('info = {}'.format(repr(info)))
+        print('dpath = {!r}'.format(dpath))
+        assert info['out'].strip() == dpath
+
+
+def test_env():
+    import sys
+    import os
+    if not sys.platform.startswith('win32'):
+        env = os.environ.copy()
+        env.update({'UBELT_TEST_ENV': '42'})
+        info = cmd('echo $UBELT_TEST_ENV', env=env, shell=True)
+        print(info['out'])
+        assert info['out'].strip() == env['UBELT_TEST_ENV']
+
+
+if __name__ == '__main__':
+    """
+        pytest ubelt/tests/test_cmd.py -s
+
+        python ~/code/ubelt/ubelt/tests/test_cmd.py test_cmd_veryverbose
+    """
+
+    import xdoctest
+    xdoctest.doctest_module(__file__)

--- a/tests/test_cmdutils.py
+++ b/tests/test_cmdutils.py
@@ -337,21 +337,12 @@ def test_cmd_stderr():
 
 
 def test_cmd_tee_auto():
-    """
-    pytest ubelt/tests/test_cmd.py -k tee_backend
-    pytest ubelt/tests/test_cmd.py
-    """
     command = 'python -c "for i in range(100): print(str(i))"'
     result = cmd(command, verbose=0, tee_backend='auto')
     assert result['out'] == '\n'.join(list(map(str, range(100)))) + '\n'
 
 
 def test_cmd_tee_thread():
-    """
-    CommandLine:
-        pytest ubelt/tests/test_cmd.py::test_cmd_tee_thread -s
-        python ubelt/tests/test_cmd.py test_cmd_tee_thread
-    """
     if 'tqdm' in sys.modules:
         if tuple(map(int, sys.modules['tqdm'].__version__.split('.'))) < (4, 19):
             pytest.skip(reason='threads cause issues with early tqdms')
@@ -384,19 +375,12 @@ def test_cmd_tee_select():
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='not available on win32')
 def test_cmd_tee_badmethod():
-    """
-    pytest ubelt/tests/test_cmd.py::test_cmd_tee_badmethod
-    """
     command = 'python -c "for i in range(100): print(str(i))"'
     with pytest.raises(ValueError):
         cmd(command, verbose=2, tee_backend='bad tee backend')
 
 
 def test_cmd_multiline_stdout():
-    """
-    python ubelt/tests/test_cmd.py test_cmd_multiline_stdout
-    pytest ubelt/tests/test_cmd.py::test_cmd_multiline_stdout
-    """
     command = 'python -c "for i in range(10): print(str(i))"'
     result = cmd(command, verbose=0)
     assert result['out'] == '\n'.join(list(map(str, range(10)))) + '\n'
@@ -407,7 +391,7 @@ def test_cmd_interleaved_streams_sh():
     """
     A test that ``Crosses the Streams'' of stdout and stderr
 
-    pytest ubelt/tests/test_cmd.py::test_cmd_interleaved_streams_sh
+    pytest tests/test_cmd.py::test_cmd_interleaved_streams_sh
     """
     if False:
         sh_script = codeblock(
@@ -489,14 +473,10 @@ def test_cmd_interleaved_streams_py():
 
 
 def test_cwd():
-    """
-    CommandLine:
-        python ~/code/ubelt/ubelt/tests/test_cmd.py test_cwd
-    """
     import sys
     import os
     if not sys.platform.startswith('win32'):
-        dpath = ensure_app_resource_dir('ubelt')
+        dpath = ensure_app_resource_dir('boltons')
         dpath = os.path.realpath(dpath)
         info = cmd('pwd', cwd=dpath, shell=True)
         # print('info = {}'.format(repr2(info, nl=1)))
@@ -517,11 +497,5 @@ def test_env():
 
 
 if __name__ == '__main__':
-    """
-        pytest ubelt/tests/test_cmd.py -s
-
-        python ~/code/ubelt/ubelt/tests/test_cmd.py test_cmd_veryverbose
-    """
-
     import xdoctest
     xdoctest.doctest_module(__file__)

--- a/tests/test_flatapi.py
+++ b/tests/test_flatapi.py
@@ -1,0 +1,6 @@
+def test_flatapi():
+    import boltons
+    # calling enable flatapi will make everything top level
+    boltons.enable_flatapi()
+    assert hasattr(boltons, 'get_python_info')
+    boltons.get_python_info()


### PR DESCRIPTION
This is a bigger PR, even though it only contains 2 functions: cmd and enable_flatapi. However the first of these functions is one of my most useful tools as measured by the latest [ubelt](https://github.com/Erotemic/ubelt) documentation: (in clocks in at [82 times used in a non-ubelt project]( https://ubelt.readthedocs.io/en/latest/), placing at 14 / 127 of my most frequently used functions). The second is a developer convenience that incurs minimal overhead during runtime.  

------

# New Function: cmd


Lets start with cmd first. The `boltons/cmdutils.py` and `tests\test_cmdutils.py` are the key contributions of this PR. There are a few other minor changes, but I can remove those if need-be. 

At its most basic it just executes some shell code. The reason this is better than subprocess.Popen (other than the name is much easier to type) is because it allows you to easily "tee" the output of your shell code. You can get the output in a dictionary and have it print to stdout at the same time and in real time (mostly, up to buffering issues that are frankly over my head). This is really useful when developing because you want to see the output of your long running process, but you might also want to be able to interact with it. In addition to these features you can also "detach" the process and run it asynchronously in the background. 


I think cmd would be a really useful addition to boltons. I could talk about `cmd` a lot, but I'm just going to let its signature speak for itself: 

```python
def cmd(command, shell=False, detach=False, cwd=None,
        env=None, tee=None, tee_backend='auto', verbose=0):
    """
    Executes a command in a subprocess.

    The advantage of this wrapper around subprocess is that
    (1) you control if the subprocess prints to stdout,
    (2) the text written to stdout and stderr is returned for parsing,
    (3) cross platform behavior that lets you specify the command as a string
    or tuple regardless of whether or not shell=True.
    (4) ability to detach, return the process object and allow the process to
    run in the background (eventually we may return a Future object instead).

    Implementation is based on the collection of code samples on stackoverflow
    [1]_ [2]_ [3]_.


    Args:
        command (str or Sequence): bash-like command string or tuple of
            executable and args

        shell (bool, default=False): if True, process is run in shell.

        detach (bool, default=False):
            if True, process is detached and run in background.

        cwd (PathLike, optional): path to run command

        env (str, optional): environment passed to Popen

        tee (bool, optional): if True, simultaneously writes to stdout while
            capturing output from the command. If not specified, defaults to
            True if verbose > 0.  If detach is True, then this argument is
            ignored.

        tee_backend (str, optional): backend for tee output.
            Valid choices are: "auto", "select" (POSIX only), and "thread".

        verbose (int, default=0): verbosity mode. Can be 0, 1, 2, or 3.
            0 is quiet, 3 is loud.

    Returns:
        dict: info - information about command status.
            if detach is False ``info`` contains captured standard out,
            standard error, and the return code
            if detach is False ``info`` contains a reference to the process.

    Notes:

        * While this function strives to be cross-platform, there are certain
          insurmountable issues that arise when handling multiple shell
          languages.

        * Inputs can either be text or tuple based. On UNIX we ensure
            conversion to text if shell=True, and to tuple if shell=False. On
            windows, the input is always text based.  See [3]_ for a potential
            cross-platform shlex solution for windows.

    References:
        .. [1] https://stackoverflow.com/questions/11495783/redirect-subprocess-stderr-to-stdout
        .. [2] https://stackoverflow.com/questions/7729336/display-subprocess-stdout-without-distorti
        .. [3] https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex

    Example:
        >>> info = cmd(('echo', 'simple cmdline interface'), verbose=1)
        >>> print(info)  # xdoctest: +IGNORE_WANT
        simple cmdline interface
        {'out': 'simple cmdline interface\n',
         'err': '',
         'ret': 0,
         'proc': <subprocess.Popen at 0x7f0a4723a2e8>,
         'cwd': None,
         'command': "echo 'simple cmdline interface'"}

        >>> # The following commands demonstrate multiple ways co call cmd
        >>> info = cmd('echo str noshell', verbose=0)
        >>> assert info['out'].strip() == 'str noshell'

        >>> # windows echo will output extra single quotes
        >>> info = cmd(('echo', 'tuple noshell'), verbose=0)
        >>> assert info['out'].strip().strip("'") == 'tuple noshell'

        >>> # Note this command is formatted to work on win32 and unix
        >>> info = cmd('echo str&&echo shell', verbose=0, shell=True)
        >>> assert info['out'].strip() == 'str' + chr(10) + 'shell'

        >>> info = cmd(('echo', 'tuple shell'), verbose=0, shell=True)
        >>> assert info['out'].strip().strip("'") == 'tuple shell'
    """
```



------

# New Function: enable_flatapi

Next is "enable_flatapi", which you'll have to tell me if you like or not. It lazily populates the global boltons API so everything is top-level (which helps reduce coder keystrokes). I used my [mkinit](https://github.com/Erotemic/mkinit) tool to autogenerate the import statements needed to declare all boltons functions in a local scope, then I simply write to the globals scope. By default it does nothing but define one function in `__init__`, however if you call that function, then all of a sudden you can do 

```python
import boltons
boltons.enable_flatapi()
print(boltons.get_python_info())
```

You can also set `BOLTONS_ENABLE_FLATAPI=TRUE` in your environment to enable the behavior by default. I personally like this feature a lot; I think it adds minimal complexity to achieve a useful behavior. 


------

# Notes

Also note a pretty cool refactoring technique I did. I left the command line in. 
When I needed to port my tests for cmd from ubelt to boltons, I needed to remove the dependencies on ubelt. I did this with a refactoring tool that currently exists in my netharn package on gitlab. I basically used this shell command:

```bash
xdoctest -m netharn.export.closer _closefile --fpath=$HOME/code/boltons/tests/test_cmdutils.py --modnames=ubelt,
```

to execute a "[Closer](https://gitlab.kitware.com/computer-vision/netharn/blob/dev/0.5.3/netharn/export/closer.py#L922)" that recursively goes finds all dependencies on a particular package and recursively goes through that package to copy and paste all the relevant bits of code statically to the top of the file  (note: my package does not execute the code to do this). Because its auto-generated its not perfect, so I did a bit of manual cleanup at the end to tie up the lose ends. It definitely made the task of porting code much less time consuming than it usually is. I mention it because I think it has the potential to become a really powerful refactoring tool, and I'd be interested in your opinion.