### PR TITLE
Add Python 3.9 compatibility

### DIFF
--- a/boltons/ecoutils.py
+++ b/boltons/ecoutils.py
@@ -374,7 +374,7 @@ def get_profile_json(indent=False):
         def dumps(val, indent):
             ret = _fake_json_dumps(val, indent=indent)
             if not indent:
-                ret = re.sub('\n\s*', ' ', ret)
+                ret = re.sub(r'\n\s*', ' ', ret)
             return ret
 
     data_dict = get_profile()

--- a/boltons/formatutils.py
+++ b/boltons/formatutils.py
@@ -53,7 +53,7 @@ __all__ = ['DeferredValue', 'get_format_args', 'tokenize_format_str',
 
 _pos_farg_re = re.compile('({{)|'         # escaped open-brace
                           '(}})|'         # escaped close-brace
-                          '({[:!.\[}])')  # anon positional format arg
+                          r'({[:!.\[}])')  # anon positional format arg
 
 
 def construct_format_field_str(fname, fspec, conv):

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -393,7 +393,7 @@ class cachedproperty(object):
 
 
 class URL(object):
-    """The URL is one of the most ubiquitous data structures in the
+    r"""The URL is one of the most ubiquitous data structures in the
     virtual and physical landscape. From blogs to billboards, URLs are
     so common, that it's easy to overlook their complexity and
     power.

--- a/misc/linkify_changelog.py
+++ b/misc/linkify_changelog.py
@@ -6,8 +6,8 @@ import sys
 BASE_RTD_URL = 'http://boltons.readthedocs.org/en/latest/'
 BASE_ISSUES_URL = 'https://github.com/mahmoud/boltons/issues/'
 
-_issues_re = re.compile('#(\d+)')
-_member_re = re.compile('((\w+utils)\.[a-zA-Z0-9_.]+)')
+_issues_re = re.compile(r'#(\d+)')
+_member_re = re.compile(r'((\w+utils)\.[a-zA-Z0-9_.]+)')
 
 URL_MAP = {}
 

--- a/misc/table_html_app.py
+++ b/misc/table_html_app.py
@@ -88,7 +88,10 @@ class BasicRender(object):
         self.autotable_render = AutoTableRenderer()
 
     def render_response(self, request, context, _route):
-        from collections import Sized
+        try:
+            from collections.abc import Sized
+        except ImportError:
+            from collections import Sized
         if isinstance(context, basestring):  # already serialized
             if self._guess_json(context):
                 return Response(context, mimetype="application/json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import sys
 import re
 
 
-_VERSION_MARKER = re.compile('_py(?P<major_version>\d)(?P<minor_version>\d)?')
+_VERSION_MARKER = re.compile(r'_py(?P<major_version>\d)(?P<minor_version>\d)?')
 
 
 def pytest_ignore_collect(path, config):

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -88,10 +88,14 @@ def test_clear():
 
 
 def test_types():
-    import collections
+    try:
+        from collections.abc import MutableMapping
+    except ImportError:
+        from collections import MutableMapping
+
     omd = OMD()
     assert isinstance(omd, dict)
-    assert isinstance(omd, collections.MutableMapping)
+    assert isinstance(omd, MutableMapping)
 
 
 def test_multi_correctness():


### PR DESCRIPTION
* Import ABC from `collections.abc`.
* Use raw strings to fix deprecation warnings.

Fixes #237 #236 