### PR TITLE
Non-decorator version of funcutils.wraps and option to hide wrapped function.

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -536,9 +536,10 @@ def update_wrapper(wrapper, func, injected=None, expected=None, build_from=None,
             the wrapper (the opposite of *injected*). See
             :meth:`FunctionBuilder.add_arg()` for more details.
         build_from (function): The callable from which the new wrapper
-            is built. Defaults to *func*. Useful in some specific cases
-            where wrapper and func have the same arguments but differ on
-            which are keyword-only and positional-only.
+            is built. Defaults to *func*, unless *wrapper* is partial object
+            built from *func*, in which case it defaults to *wrapper*.
+            Useful in some specific cases where *wrapper* and *func* have the
+            same arguments but differ on which are keyword-only and positional-only.
         update_dict (bool): Whether to copy other, non-standard
             attributes of *func* over to the wrapper. Defaults to True.
         inject_to_varkw (bool): Ignore missing arguments when a
@@ -571,6 +572,9 @@ def update_wrapper(wrapper, func, injected=None, expected=None, build_from=None,
     hide_wrapped = kw.pop('hide_wrapped', False)
     if kw:
         raise TypeError('unexpected kwargs: %r' % kw.keys())
+
+    if isinstance(wrapper, functools.partial) and func is wrapper.func:
+        build_from = build_from or wrapper
 
     fb = FunctionBuilder.from_func(build_from or func)
 

--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -526,7 +526,11 @@ def update_wrapper(wrapper, func, injected=None, expected=None, build_from=None,
             attributes of *func* over to the wrapper. Defaults to True.
         inject_to_varkw (bool): Ignore missing arguments when a
             ``**kwargs``-type catch-all is present. Defaults to True.
+        hide_wrapped (bool): Remove reference to the wrapped function(s)
+            in the updated function.
 
+    In opposition to the built-in :func:`functools.update_wrapper` bolton's
+    version returns a copy of the function and does not modifiy anything in place.
     For more in-depth wrapping of functions, see the
     :class:`FunctionBuilder` type, on which update_wrapper was built.
     """
@@ -547,6 +551,7 @@ def update_wrapper(wrapper, func, injected=None, expected=None, build_from=None,
 
     update_dict = kw.pop('update_dict', True)
     inject_to_varkw = kw.pop('inject_to_varkw', True)
+    hide_wrapped = kw.pop('hide_wrapped', False)
     if kw:
         raise TypeError('unexpected kwargs: %r' % kw.keys())
 
@@ -570,7 +575,11 @@ def update_wrapper(wrapper, func, injected=None, expected=None, build_from=None,
 
     execdict = dict(_call=wrapper, _func=func)
     fully_wrapped = fb.get_func(execdict, with_dict=update_dict)
-    fully_wrapped.__wrapped__ = func  # ref to the original function (#115)
+
+    if hide_wrapped and hasattr(fully_wrapped, '__wrapped__'):
+        del fully_wrapped.__dict__['__wrapped__']
+    elif not hide_wrapped:
+        fully_wrapped.__wrapped__ = func  # ref to the original function (#115)
 
     return fully_wrapped
 

--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -278,6 +278,7 @@ class CachedInstancePartial(functools.partial):
             obj.__dict__[name] = ret = make_method(self, obj, obj_type)
             return ret
 
+
 partial = CachedInstancePartial
 
 
@@ -814,11 +815,20 @@ class FunctionBuilder(object):
         if not callable(func):
             raise TypeError('expected callable object, not %r' % (func,))
 
-        kwargs = {'name': func.__name__,
-                  'doc': func.__doc__,
-                  'module': getattr(func, '__module__', None),  # e.g., method_descriptor
-                  'annotations': getattr(func, "__annotations__", {}),
-                  'dict': getattr(func, '__dict__', {})}
+        if isinstance(func, functools.partial):
+            if _IS_PY2:
+                raise ValueError('Cannot build FunctionBuilder instances from partials in python 2.')
+            kwargs = {'name': func.func.__name__,
+                      'doc': func.func.__doc__,
+                      'module': getattr(func.func, '__module__', None),  # e.g., method_descriptor
+                      'annotations': getattr(func.func, "__annotations__", {}),
+                      'dict': getattr(func.func, '__dict__', {})}
+        else:
+            kwargs = {'name': func.__name__,
+                      'doc': func.__doc__,
+                      'module': getattr(func, '__module__', None),  # e.g., method_descriptor
+                      'annotations': getattr(func, "__annotations__", {}),
+                      'dict': getattr(func, '__dict__', {})}
 
         kwargs.update(cls._argspec_to_dict(func))
 

--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -245,6 +245,9 @@ class InstancePartial(functools.partial):
     def __get__(self, obj, obj_type):
         return make_method(self, obj, obj_type)
 
+    def __set__(self, instance, value):
+        pass
+
 
 class CachedInstancePartial(functools.partial):
     """The ``CachedInstancePartial`` is virtually the same as
@@ -277,6 +280,9 @@ class CachedInstancePartial(functools.partial):
         except KeyError:
             obj.__dict__[name] = ret = make_method(self, obj, obj_type)
             return ret
+
+    def __set__(self, instance, value):
+        pass
 
 
 partial = CachedInstancePartial

--- a/tests/test_funcutils.py
+++ b/tests/test_funcutils.py
@@ -34,6 +34,15 @@ def test_partials():
     assert g.cached_partial_greet() == 'Hello...'
     assert CachedInstancePartial(g.greet, excitement='s')() == 'Hellos'
 
+    g.native_greet = 'native reassigned'
+    assert g.native_greet == 'native reassigned'
+
+    g.partial_greet = 'partial reassigned'
+    assert g.partial_greet == 'partial reassigned'
+
+    g.cached_partial_greet = 'cached_partial reassigned'
+    assert g.cached_partial_greet == 'cached_partial reassigned'
+
 
 def test_copy_function():
     def callee():

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -1,7 +1,5 @@
 import pytest
-import functools
-import inspect
-from boltons.funcutils import wraps, update_wrapper, FunctionBuilder
+from boltons.funcutils import wraps, FunctionBuilder
 
 
 def pita_wrap(flag=False):
@@ -106,24 +104,6 @@ def test_wraps_injected():
         inject_misc_argument_no_varkw(wrappable_varkw_func)
 
 
-def test_wraps_hide_wrapped():
-    new_func = wraps(wrappable_func, injected='b')(lambda a: wrappable_func(a, b=1))
-    new_sig = inspect.signature(new_func, follow_wrapped=True)
-
-    assert list(new_sig.parameters.keys()) == ['a', 'b']
-
-    new_func = wraps(wrappable_func, injected='b', hide_wrapped=True)(lambda a: wrappable_func(a, b=1))
-    new_sig = inspect.signature(new_func, follow_wrapped=True)
-
-    assert list(new_sig.parameters.keys()) == ['a']
-
-    new_func = wraps(wrappable_func, injected='b')(lambda a: wrappable_func(a, b=1))
-    new_new_func = wraps(new_func, injected='a', hide_wrapped=True)(lambda: new_func(a=1))
-    new_new_sig = inspect.signature(new_new_func, follow_wrapped=True)
-
-    assert len(new_new_sig.parameters) == 0
-
-
 def test_wraps_update_dict():
 
     def updated_dict(func):
@@ -150,14 +130,6 @@ def test_wraps_unknown_args():
 
     with pytest.raises(TypeError):
         fails(wrappable_func)
-
-
-def test_update_wrapper_partial():
-    wrapper = functools.partial(wrappable_varkw_func, b=1)
-    functools.update_wrapper(wrapper, wrapper.func)
-
-    fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)
-    assert fully_wrapped(1) == (1, 1)
 
 
 def test_FunctionBuilder_invalid_args():

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -1,5 +1,6 @@
 import pytest
 import functools
+import inspect
 from boltons.funcutils import wraps, update_wrapper, FunctionBuilder
 
 
@@ -103,6 +104,24 @@ def test_wraps_injected():
 
     with pytest.raises(ValueError):
         inject_misc_argument_no_varkw(wrappable_varkw_func)
+
+
+def test_wraps_hide_wrapped():
+    new_func = wraps(wrappable_func, injected='b')(lambda a: wrappable_func(a, b=1))
+    new_sig = inspect.signature(new_func, follow_wrapped=True)
+
+    assert list(new_sig.parameters.keys()) == ['a', 'b']
+
+    new_func = wraps(wrappable_func, injected='b', hide_wrapped=True)(lambda a: wrappable_func(a, b=1))
+    new_sig = inspect.signature(new_func, follow_wrapped=True)
+
+    assert list(new_sig.parameters.keys()) == ['a']
+
+    new_func = wraps(wrappable_func, injected='b')(lambda a: wrappable_func(a, b=1))
+    new_new_func = wraps(new_func, injected='a', hide_wrapped=True)(lambda: new_func(a=1))
+    new_new_sig = inspect.signature(new_new_func, follow_wrapped=True)
+
+    assert len(new_new_sig.parameters) == 0
 
 
 def test_wraps_update_dict():

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -1,6 +1,6 @@
 import pytest
-
-from boltons.funcutils import wraps, FunctionBuilder
+import functools
+from boltons.funcutils import wraps, update_wrapper, FunctionBuilder
 
 
 def pita_wrap(flag=False):
@@ -131,6 +131,14 @@ def test_wraps_unknown_args():
 
     with pytest.raises(TypeError):
         fails(wrappable_func)
+
+
+def test_update_wrapper_partial():
+    wrapper = functools.partial(wrappable_varkw_func, b=1)
+    functools.update_wrapper(wrapper, wrapper.func)
+
+    fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)
+    assert fully_wrapped(1) == (1, 1)
 
 
 def test_FunctionBuilder_invalid_args():

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -57,7 +57,7 @@ def test_wraps_py3():
 def test_update_wrapper_partial(partial_kind):
     wrapper = partial_kind.partial(wrappable_varkw_func, b=1)
 
-    fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)
+    fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func)
     assert fully_wrapped(1) == (1, 1)
 
 

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import pytest
 
 from boltons.funcutils import wraps, FunctionBuilder, update_wrapper
+import boltons.funcutils as funcutils
 
 
 def wrappable_varkw_func(a, b, **kw):
@@ -52,8 +53,9 @@ def test_wraps_py3():
         True, 'kwonly_non_roundtrippable_repr', 2)
 
 
-def test_update_wrapper_partial():
-    wrapper = functools.partial(wrappable_varkw_func, b=1)
+@pytest.mark.parametrize('partial_kind', (functools, funcutils))
+def test_update_wrapper_partial(partial_kind):
+    wrapper = partial_kind.partial(wrappable_varkw_func, b=1)
     functools.update_wrapper(wrapper, wrapper.func)
 
     fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -56,7 +56,6 @@ def test_wraps_py3():
 @pytest.mark.parametrize('partial_kind', (functools, funcutils))
 def test_update_wrapper_partial(partial_kind):
     wrapper = partial_kind.partial(wrappable_varkw_func, b=1)
-    functools.update_wrapper(wrapper, wrapper.func)
 
     fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)
     assert fully_wrapped(1) == (1, 1)

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -1,10 +1,15 @@
 
 import inspect
+import functools
 from collections import defaultdict
 
 import pytest
 
-from boltons.funcutils import wraps, FunctionBuilder
+from boltons.funcutils import wraps, FunctionBuilder, update_wrapper
+
+
+def wrappable_varkw_func(a, b, **kw):
+    return a, b
 
 
 def pita_wrap(flag=False):
@@ -45,6 +50,14 @@ def test_wraps_py3():
 
     assert kwonly_non_roundtrippable_repr() == (
         True, 'kwonly_non_roundtrippable_repr', 2)
+
+
+def test_update_wrapper_partial():
+    wrapper = functools.partial(wrappable_varkw_func, b=1)
+    functools.update_wrapper(wrapper, wrapper.func)
+
+    fully_wrapped = update_wrapper(wrapper, wrappable_varkw_func, build_from=wrapper)
+    assert fully_wrapped(1) == (1, 1)
 
 
 def test_remove_kwonly_arg():


### PR DESCRIPTION
Hi!

As as discussed in #242, here is my suggestion to add an edge case to the usage of `funcutils.wraps`. 
The situation is that if the wrapped and wrapper function have the same arguments but differ as to which are keyword-only or positional-only, the function returned by `wraps` will fail as the wrong "invocation string" was inserted in the process. A solution to this is to create the internal `FunctionBuilder`instance from the wrapper instead of the wrapped. As it didn't make sense to simply add an argument to `wraps`, I decided to replicate the structure of the built-in `functools` and add a `update_wrapper` function, of which `wraps` is only a `partial` call.

This solves a problem that originated from using partials. Code that now works to wrap those is as follow:
```python
import functools
from boltons import funcutils

def func(a, b=1, c=1):  # Has the signature "a, b=1, c=1"
    return a, b, c

wrapper = partial(func, b=2)
functools.update_wrapper(wapper, func)  # Needed as FunctionBuilder will look for some attributes like __name__ that are not updated directly with `partial`.
# wrapper has the signature; "a, *, b=2, c=1"

new_func = funcutils.update_wrapper(wrapper, func, build_from=wrapper, injected='b')
# new_func now has the signature : "a, *, c=1"
new_func(1)  # Prints : 1, 2, 1, 
```

Also, another small improvement I made here is to add an option to completely hide the wrapped function in the new one returned. Most IDEs use `inspect.signature` to extract the signature functions that they display to the user. However, by default, `signature` follows all wrapped functions until the innermost, so the user doesn't see the updated signature. One could use the `follow_wrapped=False` option, but I believe offering the possibility here could be nice.

Closes #242