### PR TITLE
fix(site): intersphinx link to recent PY2.7-->PY3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/2.7', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
Update link used by `sphinx.ext.intersphinx` extension
to standard python docs, from PY2.7 --> PY alone (currently meant PY3),
so links to standard lib do not point to (almost) EOL Python.