### PR TITLE
Use chain.from_iterable in listutils.py

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -199,7 +199,7 @@ class BarrelList(list):
         return cls(it)
 
     def __iter__(self):
-        return chain(*self.lists)
+        return chain.from_iterable(self.lists)
 
     def __reversed__(self):
         return chain.from_iterable(reversed(l) for l in reversed(self.lists))


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.