### PR TITLE
MacPorts Instructions Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <a href="https://boltons.readthedocs.io/en/latest/"><img src="https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat"></a>
 <a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/v/boltons.svg"></a>
 <a href="https://anaconda.org/conda-forge/boltons"><img src="https://img.shields.io/conda/vn/conda-forge/boltons.svg"></a>
+<a href="https://ports.macports.org/port/py-boltons/summary"><img src="https://img.shields.io/badge/macports-v20.2.1-blue?logo=Apple&logoColor=white"></a>
 <a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/pyversions/boltons.svg"></a>
 <a href="http://calver.org"><img src="https://img.shields.io/badge/calver-YY.MINOR.MICRO-22bfda.svg"></a>
 
@@ -56,6 +57,12 @@ Boltons can be added to a project in a few ways. There's the obvious one:
 ```bash
 pip install boltons
 ```
+On macOS, it can also be installed via [MacPorts](https://ports.macports.org/port/py-boltons/summary):
+
+```bash
+sudo port install py-boltons
+```
+
 
 Then, [thanks to PyPI][boltons_pypi], dozens of boltons are just an import away:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,10 @@ Boltons can be added to a project in a few ways. There's the obvious one::
 
   pip install boltons
 
+On macOS, it can also be installed via `MacPorts`_::
+
+  sudo port install py-boltons
+
 Then dozens of boltons are just an import away::
 
   from boltons.cacheutils import LRU
@@ -65,6 +69,8 @@ consider other integration options. See the :ref:`Integration
 details.
 
 Boltons is tested against Python 2.6-2.7, 3.4-3.7, and PyPy.
+
+.. _MacPorts: https://ports.macports.org/port/py-boltons/summary
 
 Third-party packages
 --------------------


### PR DESCRIPTION
Closes https://github.com/mahmoud/boltons/issues/264. Adds documentation for how to install boltons via MacPorts.