### PR TITLE
Fix Python 3.9 compatibility for FrozenDict due to PEP 584 implementation.

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -1076,7 +1076,7 @@ class FrozenDict(dict):
         "raises a TypeError, because FrozenDicts are immutable"
         raise TypeError('%s object is immutable' % self.__class__.__name__)
 
-    __setitem__ = __delitem__ = update = _raise_frozen_typeerror
+    __ior__ = __setitem__ = __delitem__ = update = _raise_frozen_typeerror
     setdefault = pop = popitem = clear = _raise_frozen_typeerror
 
     del _raise_frozen_typeerror

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import sys
 import pytest
 
 from boltons.dictutils import OMD, OneToOne, ManyToMany, FrozenDict, subdict, FrozenHashError
@@ -432,6 +433,15 @@ def test_frozendict():
     return
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+def test_frozendict_ior():
+    data = {'a': 'A', 'b': 'B'}
+    fd = FrozenDict(data)
+
+    with pytest.raises(TypeError, match=".*FrozenDicts are immutable.*"):
+        fd |= fd
+
+
 def test_frozendict_api():
     # all the read-only methods that are fine
     through_methods = ['__class__',
@@ -452,8 +462,10 @@ def test_frozendict_api():
                        '__lt__',
                        '__ne__',
                        '__new__',
+                       '__or__',
                        '__reduce__',
                        '__reversed__',
+                       '__ror__',
                        '__setattr__',
                        '__sizeof__',
                        '__str__',


### PR DESCRIPTION
Python 3.9 implements PEP 584 that supports union using `|` and `|=`. It also implements `__or__`, `__ior__` and `__ror__`. In these methods `__ior__` mutates the dictionary which shouldn't be done for FrozenDict. Python 3.8 and below raise `TypeError` since `|` and `|=` are not implemented but `|=` goes through for Python 3.9 hence add it to the list of methods that raise `TypeError`.

Fixes #270 