### PR TITLE
Adds noop function satisfying PEP 559

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -1075,4 +1075,26 @@ except ImportError:
                 setattr(cls, opname, opfunc)
         return cls
 
+def noop(*args, **kwargs):
+    """
+    Simple function that should be used when no effect is desired.
+    An alternative to checking for  an optional function type parameter.
+
+    e.g.
+    def decorate(func, pre_func=None, post_func=None):
+        if pre_func:
+            pre_func()
+        func()
+        if post_func:
+            post_func()
+
+    vs
+
+    def decorate(func, pre_func=noop, post_func=noop):
+        pre_func()
+        func()
+        post_func()
+    """
+    return None
+
 # end funcutils.py

--- a/tests/test_funcutils.py
+++ b/tests/test_funcutils.py
@@ -4,7 +4,8 @@ from boltons.funcutils import (copy_function,
                                total_ordering,
                                format_invocation,
                                InstancePartial,
-                               CachedInstancePartial)
+                               CachedInstancePartial,
+                               noop)
 
 
 class Greeter(object):
@@ -78,3 +79,8 @@ def test_format_invocation():
     assert format_invocation('f', ('a', 'b')) == "f('a', 'b')"
     assert format_invocation('g', (), {'x': 'y'})  == "g(x='y')"
     assert format_invocation('h', ('a', 'b'), {'x': 'y', 'z': 'zz'}) == "h('a', 'b', x='y', z='zz')"
+
+def test_noop():
+    assert noop() is None
+    assert noop(1, 2) is None
+    assert noop(a=1, b=2) is None


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0559/

I've found recently a need to define a noop function when building functions that have logic that may need to be ran before or after a target function.  This is often used to setup some state necessary for the main function being ran or to run some cleanup functionality after a function is ran.  I found pep 559 when searching if python had a built in noop function, and saw that it was rejected.  I don't really want to have to define a noop function every time I work on a project that could use some noop functionality so I thought this would be perfect for boltons!

I thought the best location for this function is funcutils but please let me know if it isn't appropriate. Thanks for considering the PR!