### PR TITLE
Clarify docstring example for atomic_save

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -223,8 +223,12 @@ else:
 
 
 def atomic_save(dest_path, **kwargs):
-    """A convenient interface to the :class:`AtomicSaver` type. See the
-    :class:`AtomicSaver` documentation for details.
+    """A convenient interface to the :class:`AtomicSaver` type. Example:
+    
+    >>> with atomic_save("/tmp/file.txt", text_mode=True) as fo:
+    ...     data = fo.read()
+    
+    See the :class:`AtomicSaver` documentation for details.
     """
     return AtomicSaver(dest_path, **kwargs)
 

--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -324,7 +324,7 @@ class AtomicSaver(object):
             respect the user's configured `umask`_, usually resulting
             in octal 0644 or 0664.
         text_mode (bool): Whether to open the destination file in text
-            mode (i.e., ``'w'`` not ``'wb'``). Defaults to ``True``.
+            mode (i.e., ``'w'`` not ``'wb'``). Defaults to ``False`` (``wb``).
         part_file (str): Name of the temporary *part_file*. Defaults
             to *dest_path* + ``.part``. Note that this argument is
             just the filename, and not the full path of the part

--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -320,7 +320,7 @@ class AtomicSaver(object):
             respect the user's configured `umask`_, usually resulting
             in octal 0644 or 0664.
         text_mode (bool): Whether to open the destination file in text
-            mode.
+            mode (i.e., ``'w'`` not ``'wb'``). Defaults to ``True``.
         part_file (str): Name of the temporary *part_file*. Defaults
             to *dest_path* + ``.part``. Note that this argument is
             just the filename, and not the full path of the part


### PR DESCRIPTION
This PR clarifies that `text_mode=True` means `w` and `text_mode=False` is `wb`. It also gives an example usage.

At first glance, I was confused by the docs for `atomic_save()` until duckduckgo lead me to issue #249 . If you don't want this, I won't be offended.

Also, [my project](https://github.com/cltk/cltk) uses `cachedproperty` extensively. Thank you, I don't know what we'd do without it!