### PR TITLE
Update Python 3.9 FrozenDict exception message

### DIFF
--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -438,7 +438,7 @@ def test_frozendict_ior():
     data = {'a': 'A', 'b': 'B'}
     fd = FrozenDict(data)
 
-    with pytest.raises(TypeError, match=".*FrozenDicts are immutable.*"):
+    with pytest.raises(TypeError, match=".*FrozenDict.*immutable.*"):
         fd |= fd
 
 


### PR DESCRIPTION
The exception message with Python 3.9.2 is 'FrozenDict object is immutable'