### PR TITLE
Update MacPorts Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://boltons.readthedocs.io/en/latest/"><img src="https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat"></a>
 <a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/v/boltons.svg"></a>
 <a href="https://anaconda.org/conda-forge/boltons"><img src="https://img.shields.io/conda/vn/conda-forge/boltons.svg"></a>
-<a href="https://ports.macports.org/port/py-boltons/summary"><img src="https://img.shields.io/badge/macports-v20.2.1-blue?logo=Apple&logoColor=white"></a>
+<a href="https://ports.macports.org/port/py-boltons/summary"><img src="https://repology.org/badge/version-for-repo/macports/python:boltons.svg?header=🍎 MacPorts"></a>
 <a href="https://pypi.python.org/pypi/boltons"><img src="https://img.shields.io/pypi/pyversions/boltons.svg"></a>
 <a href="http://calver.org"><img src="https://img.shields.io/badge/calver-YY.MINOR.MICRO-22bfda.svg"></a>
 


### PR DESCRIPTION
Hi @mahmoud 👋. Following https://github.com/macports/macports-ports/commit/c3f1b4c50e8e0dc6c08abd44336c5441e062d9be, I've updated boltons on MacPorts to the latest version! 🎉

This PR changes the MacPorts badge so that it auto updates the version number to follow the portfile. Currently at the time of writing, it suggests MacPorts isn't providing the latest version since I only updated it recently, but it should turn green soon.

Thank you for maintaining this amazing project.