### PR TITLE
Chaining `boltons.urlutils.URL.navigate()` results in `TypeError`

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -654,7 +654,8 @@ class URL(object):
             if dest.path.startswith(u'/'):   # absolute path
                 new_path_parts = list(dest.path_parts)
             else:  # relative path
-                new_path_parts = self.path_parts[:-1] + dest.path_parts
+                new_path_parts = list(self.path_parts[:-1]) \
+                               + list(dest.path_parts)
         else:
             new_path_parts = list(self.path_parts)
             if not query_params:

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -271,11 +271,11 @@ def test_rel_navigate():
 @pytest.mark.parametrize(
     ('expected',            'base',             'a',    'b'), [
     ('https://host/b',      'https://host',     'a',    '/b'),
-    ('https://host/a/b',    'https://host',     'a',    'b'),
+    ('https://host/b',    'https://host',     'a',    'b'),
     ('https://host/a/b',    'https://host',     'a/',   'b'),
-    ('https://host/a/b',    'https://host',     '/a',   'b'),
+    ('https://host/b',    'https://host',     '/a',   'b'),
     ('https://host/a/b',    'https://host/a/',  None,   'b'),
-    ('https://host/a/b',    'https://host/a',   None,   'b'),
+    ('https://host/b',    'https://host/a',   None,   'b'),
 ])
 def test_chained_navigate(expected, base, a, b):
     """Chained :meth:`navigate` calls produces correct results."""

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -268,25 +268,6 @@ def test_rel_navigate():
     return
 
 
-@pytest.mark.parametrize(
-    ('expected', 'base', 'paths'), [
-    ('https://host/b', 'https://host', ['a', '/b']),
-    ('https://host/b', 'https://host', ['a', 'b']),
-    ('https://host/a/b', 'https://host', ['a/', 'b']),
-    ('https://host/b', 'https://host', ['/a', 'b']),
-    ('https://host/a/b', 'https://host/a/', [None, 'b']),
-    ('https://host/b', 'https://host/a', [None, 'b']),
-])
-def test_chained_navigate(expected, base, paths):
-    """Chained :meth:`navigate` calls produces correct results."""
-    url = URL(base)
-
-    for path in paths:
-        url = url.navigate(path)
-
-    assert expected == url.to_text()
-
-
 def test_navigate():
     orig_text = u'http://a.b/c/d?e#f'
     orig = URL(orig_text)
@@ -330,6 +311,25 @@ def test_navigate():
     assert navd.to_text() == _dest_text
     navd = orig.navigate(_dest_text)
     assert navd.to_text() == _dest_text
+
+
+@pytest.mark.parametrize(
+    ('expected', 'base', 'paths'), [
+    ('https://host/b', 'https://host', ('a', '/b', )),
+    ('https://host/b', 'https://host', ('a', 'b', )),
+    ('https://host/a/b', 'https://host', ('a/', 'b', )),
+    ('https://host/b', 'https://host', ('/a', 'b', )),
+    ('https://host/a/b', 'https://host/a/', (None, 'b', )),
+    ('https://host/b', 'https://host/a', (None, 'b', )),
+])
+def test_chained_navigate(expected, base, paths):
+    """Chained :meth:`navigate` calls produces correct results."""
+    url = URL(base)
+
+    for path in paths:
+        url = url.navigate(path)
+
+    assert expected == url.to_text()
 
 
 # TODO: RFC3986 6.2.3 (not just for query add, either)

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -268,6 +268,23 @@ def test_rel_navigate():
     return
 
 
+@pytest.mark.parametrize(
+    ('expected',            'base',             'a',    'b'), [
+    ('https://host/b',      'https://host',     'a',    '/b'),
+    ('https://host/a/b',    'https://host',     'a',    'b'),
+    ('https://host/a/b',    'https://host',     'a/',   'b'),
+    ('https://host/a/b',    'https://host',     '/a',   'b'),
+    ('https://host/a/b',    'https://host/a/',  None,   'b'),
+    ('https://host/a/b',    'https://host/a',   None,   'b'),
+])
+def test_chained_navigate(expected, base, a, b):
+    """Chained :meth:`navigate` calls produces correct results."""
+    if a is not None:
+        assert expected == URL(base).navigate(a).navigate(b).to_text()
+    else:
+        assert expected == URL(base).navigate(b).to_text()
+
+
 def test_navigate():
     orig_text = u'http://a.b/c/d?e#f'
     orig = URL(orig_text)

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -269,20 +269,22 @@ def test_rel_navigate():
 
 
 @pytest.mark.parametrize(
-    ('expected',            'base',             'a',    'b'), [
-    ('https://host/b',      'https://host',     'a',    '/b'),
-    ('https://host/b',    'https://host',     'a',    'b'),
-    ('https://host/a/b',    'https://host',     'a/',   'b'),
-    ('https://host/b',    'https://host',     '/a',   'b'),
-    ('https://host/a/b',    'https://host/a/',  None,   'b'),
-    ('https://host/b',    'https://host/a',   None,   'b'),
+    ('expected', 'base', 'paths'), [
+    ('https://host/b', 'https://host', ['a', '/b']),
+    ('https://host/b', 'https://host', ['a', 'b']),
+    ('https://host/a/b', 'https://host', ['a/', 'b']),
+    ('https://host/b', 'https://host', ['/a', 'b']),
+    ('https://host/a/b', 'https://host/a/', [None, 'b']),
+    ('https://host/b', 'https://host/a', [None, 'b']),
 ])
-def test_chained_navigate(expected, base, a, b):
+def test_chained_navigate(expected, base, paths):
     """Chained :meth:`navigate` calls produces correct results."""
-    if a is not None:
-        assert expected == URL(base).navigate(a).navigate(b).to_text()
-    else:
-        assert expected == URL(base).navigate(b).to_text()
+    url = URL(base)
+
+    for path in paths:
+        url = url.navigate(path)
+
+    assert expected == url.to_text()
 
 
 def test_navigate():


### PR DESCRIPTION
Chaining `navigate()` calls like `boltons.urlutils.URL('...').navigate(...).navigate(...)` produces `TypeError: can only concatenate list (not "tuple") to list`.

`boltons.urlutils.URL('...').navigate(...).navigate(...)` should be the equivalent of 
```python
url = boltons.urlutils.URL('...').navigate(...)
url = boltons.urlutils.URL(url).navigate(...)
```

This PR extends #159 as the test cases provided are incosistent if it was manually chained.

Fixes #158, #159, #160