### PR TITLE
Added py310 to gh actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,6 @@
-name: Tests
+name: "Tests_dev"
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - 'docs/**'
@@ -18,9 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
           - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
+          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}

--- a/requirements-test-legacy.txt
+++ b/requirements-test-legacy.txt
@@ -1,0 +1,4 @@
+coverage==4.5.1
+pytest==3.0.7
+pytest-cov==2.5.1
+tox<3.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-coverage==4.5.1
-pytest==3.0.7
-pytest-cov==2.5.1
-tox<3.0
+coverage==6.2
+pytest==7.1.1
+pytest-cov==3.0.0
+tox==3.24.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-coverage==6.2
-pytest==7.1.1
-pytest-cov==3.0.0
-tox==3.24.5
+coverage==6.*
+pytest==7.*
+pytest-cov==3.*
+tox==3.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = py27,py34,py37,py39,pypy
+envlist = py{27, 34, 36, 37, 38, 39, 310, py, py3}
 [testenv]
 changedir = .tox
-deps = -rrequirements-test.txt
+deps = 
+  py{27,34,36,py,py3}: -rrequirements-test-legacy.txt
+  !py27-!py34-!py36-!pypy-!pypy3: -rrequirements-test.txt
 commands = py.test --doctest-modules {envsitepackagesdir}/boltons {toxinidir}/tests {posargs}


### PR DESCRIPTION
- Updated packages in requirements-test.txt to latest versions: the current version is incompatible with python 3.10
- Added a separate requirements-test-legacy.txt for py27, py34, py36, pypy, pypy3