### PR TITLE
Update tbutils.py to parse tracebacks with anchor lines

### DIFF
--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -682,7 +682,7 @@ def fix_print_exception():
 _frame_re = re.compile(r'^File "(?P<filepath>.+)", line (?P<lineno>\d+)'
                        r', in (?P<funcname>.+)$')
 _se_frame_re = re.compile(r'^File "(?P<filepath>.+)", line (?P<lineno>\d+)')
-
+_underline_re = re.compile(r'^[~^ ]*$')
 
 # TODO: ParsedException generator over large bodies of text
 
@@ -810,6 +810,9 @@ class ParsedException(object):
                 else:
                     frame_dict['source_line'] = next_line_stripped
                     line_no += 1
+                if _underline_re.match(tb_lines[line_no + 1]):
+                  # To deal with anchors
+                  line_no += 1
             else:
                 break
             line_no += 1

--- a/tests/test_tbutils_parsed_exc.py
+++ b/tests/test_tbutils_parsed_exc.py
@@ -51,3 +51,33 @@ RuntimeError"""
                                    'lineno': u'2',
                                    'funcname': u'load'}
     assert parsed_tb.to_string() == _tb_str
+
+def test_parsed_exc_with_anchor():
+    """parse a traceback with anchor lines beneath source lines"""
+    _tb_str = u"""\
+Traceback (most recent call last):
+  File "main.py", line 3, in <module>
+    print(add(1, "two"))
+          ^^^^^^^^^^^^^
+  File "add.py", line 2, in add
+    return a + b
+           ~~^~~
+TypeError: unsupported operand type(s) for +: 'int' and 'str'"""
+
+    parsed_tb = ParsedException.from_string(_tb_str)
+
+    assert parsed_tb.exc_type == 'TypeError'
+    assert parsed_tb.exc_msg == "unsupported operand type(s) for +: 'int' and 'str'"
+    assert parsed_tb.frames == [{'source_line': u'print(add(1, "two"))',
+                                  'filepath': u'main.py',
+                                  'lineno': u'3',
+                                  'funcname': u'<module>'},
+                                  {'source_line': u'return a + b',
+                                  'filepath': u'add.py',
+                                  'lineno': u'2',
+                                  'funcname': u'add'}]
+    
+    # Note: not checking the anchor lines (indices 3, 6) because column details not currently stored in ParsedException
+    _tb_str_lines = _tb_str.splitlines()
+    _tb_str_without_anchor = "\n".join(_tb_str_lines[:3] + _tb_str_lines[4:6] + _tb_str_lines[7:])
+    assert parsed_tb.to_string() == _tb_str_without_anchor


### PR DESCRIPTION
Anchors are sometimes added below the source line, (see https://github.com/python/cpython/blob/dcd6f226d6596b25b6f4004058a67acabe012120/Lib/traceback.py#L479-L510). This fix will allow parsing to continue as normal in their presence