### PR TITLE
Fix leaky monley-patching of `pprint._safe_repr` in `boltons.ecoutils`

### DIFF
--- a/boltons/ecoutils.py
+++ b/boltons/ecoutils.py
@@ -363,9 +363,10 @@ try:
         return json.dumps(val, sort_keys=True)
 
 except ImportError:
-    _real_safe_repr = pprint._safe_repr
 
     def _fake_json_dumps(val, indent=2):
+        _real_safe_repr = pprint._safe_repr
+
         # never do this. this is a hack for Python 2.4. Python 2.5 added
         # the json module for a reason.
         def _fake_safe_repr(*a, **kw):


### PR DESCRIPTION
This fix the way `pprint._safe_repr` is locally patched in `boltons.ecoutils`.

The symptoms are broken `pdb` prompt from my `pytest --pdb` calls sessions, as discribes in details at #334.

That issue being quite subtle and convoluted, I cannot find a simple and elegant way to create a unittest for this, so I propose to merge the fix as-is.

This closes #334.