### PR TITLE
fix: make copy_function work with keyword-only defaults

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -215,6 +215,8 @@ def copy_function(orig, copy_dict=True):
                        name=orig.__name__,
                        argdefs=getattr(orig, "__defaults__", None),
                        closure=getattr(orig, "__closure__", None))
+    if hasattr(orig, "__kwdefaults__"):
+        ret.__kwdefaults__ = orig.__kwdefaults__
     if copy_dict:
         ret.__dict__.update(orig.__dict__)
     return ret

--- a/tests/test_funcutils.py
+++ b/tests/test_funcutils.py
@@ -52,6 +52,11 @@ def test_copy_function():
     assert callee is not callee_copy
     assert callee() == callee_copy()
 
+    # test that the copy works with keyword-only defaults!
+    f = lambda x, *, y=2: x * y
+    f_copy = copy_function(f)
+    assert f(21) == f_copy(21) == 42
+
 
 def test_total_ordering():
     @total_ordering


### PR DESCRIPTION
At this point, we have:

```python
from boltons.funcutils import copy_function

f = lambda x, *, y=2: x * y

f_copy = copy_function(f)

assert f(21) == 42  # all goes well, but...

import pytest, re

with pytest.raises(TypeError):
    f_copy(21)  # missing 1 required keyword-only argument: 'y'
    
```

So `f_copy` isn't really a copy.

By adding

```python
...
    if hasattr(orig, "__kwdefaults__"):
        ret.__kwdefaults__ = orig.__kwdefaults__
...
```

to the function, we get the desired behavior:

```python
f = lambda x, *, y=2: x * y
f_copy = copy_function(f)
assert f(21) == f_copy(21) == 42 
```

I also extended the `test_copy_function` test function to protect this behavior in future evolutions. 