### PR TITLE
Make OMD picklable under py3, fixes #337

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -71,8 +71,10 @@ thanks to `Mark Williams`_ for all his help.
 
 try:
     from collections.abc import KeysView, ValuesView, ItemsView
+    PY3 = True
 except ImportError:
     from collections import KeysView, ValuesView, ItemsView
+    PY3 = False
 
 import itertools
 
@@ -177,7 +179,7 @@ class OrderedMultiDict(dict):
         ret = super(OrderedMultiDict, cls).__new__(cls)
         ret._clear_ll()
         return ret 
-
+    
     def __init__(self, *args, **kwargs):
         if len(args) > 1:
             raise TypeError('%s expected at most 1 argument, got %s'
@@ -188,6 +190,14 @@ class OrderedMultiDict(dict):
             self.update_extend(args[0])
         if kwargs:
             self.update(kwargs)
+
+    if PY3:
+        def __getstate__(self):
+            return list(self.iteritems(multi=True))
+        
+        def __setstate__(self, state):
+            self.clear()
+            self.update_extend(state)
 
     def _clear_ll(self):
         try:

--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -173,13 +173,17 @@ class OrderedMultiDict(dict):
        behavior, just use :meth:`~OrderedMultiDict.todict()`.
 
     """
+    def __new__(cls, *a, **kw):
+        ret = super(OrderedMultiDict, cls).__new__(cls)
+        ret._clear_ll()
+        return ret 
+
     def __init__(self, *args, **kwargs):
         if len(args) > 1:
             raise TypeError('%s expected at most 1 argument, got %s'
                             % (self.__class__.__name__, len(args)))
         super(OrderedMultiDict, self).__init__()
 
-        self._clear_ll()
         if args:
             self.update_extend(args[0])
         if kwargs:

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -78,10 +78,16 @@ def test_omd_pickle():
     import pickle
 
     empty = OMD()
-    assert pickle.loads(pickle.dumps(empty)) == empty
+    pickled = pickle.dumps(empty)
+    roundtripped = pickle.loads(pickled)
+    assert roundtripped == empty
 
-    nonempty = OMD([('a', 1), ('b', 2)])
-    assert pickle.loads(pickle.dumps(nonempty)) == nonempty
+    nonempty = OMD([('a', 1), ('b', 2), ('b', 3)])
+
+    roundtripped = pickle.loads(pickle.dumps(nonempty)) 
+    assert roundtripped == nonempty
+    assert roundtripped.getlist('b') == [2, 3]
+
 
 
 def test_clear():

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -74,6 +74,16 @@ def test_copy():
     return
 
 
+def test_omd_pickle():
+    import pickle
+
+    empty = OMD()
+    assert pickle.loads(pickle.dumps(empty)) == empty
+
+    nonempty = OMD([('a', 1), ('b', 2)])
+    assert pickle.loads(pickle.dumps(nonempty)) == nonempty
+
+
 def test_clear():
     for itemset in _ITEMSETS:
         omd = OMD(itemset)


### PR DESCRIPTION
For some reason this test passed under py2, which I guess is telling as to how long it's been since I was actively pickling.