### PR TITLE
Test and fix for #348

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,13 +60,5 @@ jobs:
           pip install -U wheel
           pip install -U setuptools
           python -m pip install -U pip
-      - name: get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-      - name: cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - run: pip install tox
       - run: tox -e py27

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,6 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '2.7', python: '2.7.18', os: ubuntu-20.04, tox: py27}
           - {name: 'PyPy3', python: 'pypy-3.9', os: ubuntu-latest, tox: pypy3}
     steps:
       - uses: actions/checkout@v2
@@ -47,3 +46,27 @@ jobs:
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}
+  tests-py27:
+    name: '2.7'
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: update pip
+        run: |
+          pip install -U wheel
+          pip install -U setuptools
+          python -m pip install -U pip
+      - name: get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+      - name: cache pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
+      - run: pip install tox
+      - run: tox -e py27

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '2.7', python: '2.7.18', os: ubuntu-latest, tox: py27}
+          - {name: '2.7', python: '2.7.18', os: ubuntu-20.04, tox: py27}
           - {name: 'PyPy3', python: 'pypy-3.9', os: ubuntu-latest, tox: pypy3}
     steps:
       - uses: actions/checkout@v2

--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -235,9 +235,10 @@ class LRI(dict):
                 else:
                     evicted = self._set_key_and_evict_last_in_ll(key, value)
                     super(LRI, self).__delitem__(evicted)
-                super(LRI, self).__setitem__(key, value)
             else:
                 link[VALUE] = value
+            super(LRI, self).__setitem__(key, value)
+        return
 
     def __getitem__(self, key):
         with self._lock:

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -167,6 +167,31 @@ def test_lru_basic():
     assert second_lru != lru
 
 
+def test_lru_dict_replacement():
+    # see issue #348
+    cache = LRU()
+
+    # Add an entry.
+    cache['a'] = 1
+
+    # Normal __getitem__ access.
+    assert cache['a'] == 1  # passes.
+    # Convert to dict.
+    assert dict(cache) == {'a': 1}  # passes.
+    # Another way to access the only value.
+    assert list(cache.values())[0] == 1  # passes.
+
+    # Replace the existing 'a' entry with a new value.
+    cache['a'] = 200
+
+    # __getitem__ works as expected.
+    assert cache['a'] == 200  # passes.
+
+    # Both dict and accessing via values() return the old entry: 1.
+    assert dict(cache) == {'a': 200}  # fails.
+    assert list(cache.values())[0] == 200
+
+
 def test_lru_with_dupes():
     SIZE = 2
     lru = LRU(max_size=SIZE)

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -167,9 +167,10 @@ def test_lru_basic():
     assert second_lru != lru
 
 
-def test_lru_dict_replacement():
+@pytest.mark.parametrize("lru_class", [LRU, LRI])
+def test_lru_dict_replacement(lru_class):
     # see issue #348
-    cache = LRU()
+    cache = lru_class()
 
     # Add an entry.
     cache['a'] = 1


### PR DESCRIPTION
The test repro'd #348, plus I checked `.values()` for good measure. It wasn't really a supported use case before, but ideally it should be; cacheutil are dict subtypes (for better or worse). 

Before merging, I should probably add LRI tests for this, just to be safe. Also need to think a little harder about whether there are more invariant tests that need to be added for the linked list.