### PR TITLE
Fix including docs and tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include README.md
 include TODO.rst
 include pytest.ini
 include tox.ini
-recursive-include docs 
-recursive-include tests
+recursive-include docs *
+recursive-include tests *


### PR DESCRIPTION
Fix the `recursive-include` statements in `MANIFEST.in` to actually include full documentation and test tree.  The statements without a list of globs were ineffective, and only `.py` files were included. Effectively, docs were missing completely and tests missed required data files (e.g. `json_test_data.txt`).