### PR TITLE
Fix `boltons.strutils.__all__` missing names

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -78,7 +78,7 @@ __all__ = ['camel2under', 'under2camel', 'slugify', 'split_punct_ws',
            'bytes2human', 'find_hashtags', 'a10n', 'gzip_bytes', 'gunzip_bytes',
            'iter_splitlines', 'indent', 'escape_shell_args',
            'args2cmd', 'args2sh', 'parse_int_list', 'format_int_list',
-           'int_list_complement', 'int_list_to_int_tuples', 'MultiReplace',
+           'complement_int_list', 'int_ranges_from_int_list', 'MultiReplace',
            'multi_replace', 'unwrap_text']
 
 


### PR DESCRIPTION
Closes #355 

Missed in https://github.com/mahmoud/boltons/commit/17c64d01c2d9837a3b60f67de664de4a2cde7918, CC @mahmoud 

This could've been caught by a linter (see Flake8/Ruff) or a type-checker (see mypy/pyright, #190)