### PR TITLE
[strutils] implements natural_enumerate

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -279,6 +279,37 @@ def pluralize(word):
     return _match_case(orig_word, plural)
 
 
+def natural_enumerate(sized_iterable, last_sep=' and ', sep=", ", wrap_item_with=""):
+    """
+    Return a string with a natural enumeration of the given items.
+
+    >>> natural_enumerate(['a', 'b', 'c', 'd'])
+    'a, b, c and d'
+    >>> natural_enumerate(['a', 'b', 'c'], ' or ')
+    'a, b or c'
+    >>> natural_enumerate(['a', 'b', 'c'], ', ')
+    'a, b, c'
+    >>> natural_enumerate(['a', 'b'], ' or ')
+    'a or b'
+    >>> natural_enumerate(['a'])
+    'a'
+    >>> natural_enumerate([])
+    ''
+    >>> natural_enumerate(['a', 'b'], wrap_item_with="`")
+    '`a` and `b`'
+    >>> natural_enumerate(['a', 'b', 'c', 'd'], " = ", sep=" + ")
+    'a + b + c = d'
+    """
+    if len(sized_iterable) == 0:
+        return ""
+    if wrap_item_with:
+        sized_iterable = [f"{wrap_item_with}{item}{wrap_item_with}" for item in sized_iterable] 
+    if len(sized_iterable) == 1:
+        return sized_iterable[0]
+    all_but_last = sep.join(i for i in sized_iterable[:-1])
+    return f"{all_but_last}{last_sep}{sized_iterable[-1]}"
+
+
 def _match_case(master, disciple):
     if not master.strip():
         return disciple


### PR DESCRIPTION
Return a string with a natural enumeration of the given items.

It's based on my contribution to IPython
https://github.com/ipython/ipython/blob/3ced24d6b07c3d66bbae5bef24fa59af25606512/IPython/utils/text.py#L729

which is an extended version of Django's  get_text_list()`
https://github.com/django/django/blob/0ee2b8c326d47387bacb713a3ab369fa9a7a22ee/django/utils/text.py#L270

```python
    >>> natural_enumerate(['a', 'b', 'c', 'd'])
    'a, b, c and d'
    >>> natural_enumerate(['a', 'b', 'c'], ' or ')
    'a, b or c'
    >>> natural_enumerate(['a', 'b', 'c'], ', ')
    'a, b, c'
    >>> natural_enumerate(['a', 'b'], ' or ')
    'a or b'
    >>> natural_enumerate(['a'])
    'a'
    >>> natural_enumerate([])
    ''
    >>> natural_enumerate(['a', 'b'], wrap_item_with="`")
    '`a` and `b`'
    >>> natural_enumerate(['a', 'b', 'c', 'd'], " = ", sep=" + ")
    'a + b + c = d'
```

I'm open to find a better name