### PR TITLE
Add CI for Python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,17 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
-          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
-          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: Linux, python: '3.12', os: ubuntu-latest, tox: py312}
+          - {name: Windows, python: '3.12', os: windows-latest, tox: py312}
+          - {name: Mac, python: '3.12', os: macos-latest, tox: py312}
+          - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: 'PyPy3', python: 'pypy-3.9', os: ubuntu-latest, tox: pypy3}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: update pip
@@ -40,7 +41,7 @@ jobs:
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
@@ -48,13 +49,13 @@ jobs:
       - run: tox -e ${{ matrix.tox }}
   tests-py27:
     name: '2.7'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: python:2.7.18-buster
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: update pip
         run: |
           pip install -U wheel

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ in the same spirit as — and yet conspicuously missing from —
 **[Full and extensive docs are available on Read The Docs.][rtd]** See
 what's new [by checking the CHANGELOG][changelog].
 
-Boltons is tested against Python 3.6-3.11, as well as Python 2.7 and PyPy3.
+Boltons is tested against Python 3.7-3.12, as well as Python 2.7 and PyPy3.
 
 [stdlib]: https://docs.python.org/3/library/index.html
 [rtd]: https://boltons.readthedocs.org/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ consider other integration options. See the :ref:`Integration
 <arch_integration>` section of the architecture document for more
 details.
 
-Boltons is tested against Python 3.7-3.11, as well as Python 2.7 and PyPy3.
+Boltons is tested against Python 3.7-3.12, as well as Python 2.7 and PyPy3.
 
 .. _MacPorts: https://ports.macports.org/port/py-boltons/summary
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='boltons',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy', ]
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,py39,py310,py311,pypy3
+envlist = py27,py37,py39,py310,py311,py312,pypy3
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt
@@ -10,4 +10,4 @@ deps =
     coverage==5.5
     pytest==4.6.11
     pytest-cov==2.12
-    
+


### PR DESCRIPTION
It appears that all the tests already pass on Python 3.12. I've also bumped some of the GitHub Actions.