### PR TITLE
Remove more redundant internal compatibility aliases

### DIFF
--- a/boltons/deprutils.py
+++ b/boltons/deprutils.py
@@ -30,9 +30,8 @@
 
 
 import sys
+from types import ModuleType
 from warnings import warn
-
-ModuleType = type(sys)
 
 # todo: only warn once
 

--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -121,15 +121,6 @@ def floor(x, options=None):
     return options[i - 1]
 
 
-try:
-    _int_types = (int, long)
-    bytes = str
-except NameError:
-    # py3 has no long
-    _int_types = (int,)
-    unicode = str
-
-
 class Bits:
     '''
     An immutable bit-string or bit-array object.
@@ -147,12 +138,12 @@ class Bits:
     __slots__ = ('val', 'len')
 
     def __init__(self, val=0, len_=None):
-        if type(val) not in _int_types:
+        if type(val) is not int:
             if type(val) is list:
                 val = ''.join(['1' if e else '0' for e in val])
             if type(val) is bytes:
                 val = val.decode('ascii')
-            if type(val) is unicode:
+            if type(val) is str:
                 if len_ is None:
                     len_ = len(val)
                     if val.startswith('0x'):
@@ -164,7 +155,7 @@ class Bits:
                         val = int(val, 2)
                     else:
                         val = 0
-            if type(val) not in _int_types:
+            if type(val) is not int:
                 raise TypeError(f'initialized with bad type: {type(val).__name__}')
         if val < 0:
             raise ValueError('Bits cannot represent negative values')

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -57,10 +57,9 @@ import operator
 from datetime import tzinfo, timedelta, date, datetime
 
 
-def total_seconds(td):
-    # For legacy compatibility.
-    # boltons used to offer an implementation of total_seconds for Python <2.7
-    return timedelta.total_seconds(td)
+# For legacy compatibility.
+# boltons used to offer an implementation of total_seconds for Python <2.7
+total_seconds = timedelta.total_seconds
 
 
 def dt_to_timestamp(dt):

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -55,8 +55,6 @@ import socket
 import string
 from unicodedata import normalize
 
-unicode = str
-
 # The unreserved URI characters (per RFC 3986 Section 2.3)
 _UNRESERVED_CHARS = frozenset('~-._0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                               'abcdefghijklmnopqrstuvwxyz')
@@ -124,9 +122,9 @@ DEFAULT_ENCODING = 'utf8'
 
 def to_unicode(obj):
     try:
-        return unicode(obj)
+        return str(obj)
     except UnicodeDecodeError:
-        return unicode(obj, encoding=DEFAULT_ENCODING)
+        return str(obj, encoding=DEFAULT_ENCODING)
 
 
 # regex from gruber via tornado
@@ -174,7 +172,7 @@ def find_all_links(text, with_text=False, default_scheme='https', schemes=()):
     _add = ret.append
 
     def _add_text(t):
-        if ret and isinstance(ret[-1], unicode):
+        if ret and isinstance(ret[-1], str):
             ret[-1] += t
         else:
             _add(t)
@@ -311,7 +309,7 @@ def unquote_to_bytes(string):
         # Is it a string-like object?
         string.split
         return b''
-    if isinstance(string, unicode):
+    if isinstance(string, str):
         string = string.encode('utf-8')
     bits = string.split(b'%')
     if len(bits) == 1:
@@ -741,7 +739,7 @@ class URL:
             # TODO: 0 port?
             if self.port and self.port != self.default_port:
                 _add(':')
-                _add(unicode(self.port))
+                _add(str(self.port))
         return ''.join(parts)
 
     def to_text(self, full_quote=False):
@@ -903,7 +901,7 @@ def parse_url(url_text):
     >>> sorted(res.keys())  # res is a basic dictionary
     ['_netloc_sep', 'authority', 'family', 'fragment', 'host', 'password', 'path', 'port', 'query', 'scheme', 'username']
     """
-    url_text = unicode(url_text)
+    url_text = str(url_text)
     # raise TypeError('parse_url expected text, not %r' % url_str)
     um = _URL_RE.match(url_text)
     try:


### PR DESCRIPTION
Noticed in https://github.com/python/typeshed/pull/11804 . Follow-up to #362

idk if you'd like to drop tests for `total_ordering` since boltons is no longer implementing it.