### PR TITLE
Fix Python 3.13 beta test failures (fixes #365)

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -249,6 +249,11 @@ class InstancePartial(functools.partial):
     """
     @property
     def _partialmethod(self):
+        # py3.13 switched from _partialmethod to __partialmethod__, this is kept for backwards compat <=py3.12
+        return self.__partialmethod__
+    
+    @property
+    def __partialmethod__(self):
         return functools.partialmethod(self.func, *self.args, **self.keywords)
 
     def __get__(self, obj, obj_type):
@@ -268,12 +273,12 @@ class CachedInstancePartial(functools.partial):
     """
     @property
     def _partialmethod(self):
-        return functools.partialmethod(self.func, *self.args, **self.keywords)
+        # py3.13 switched from _partialmethod to __partialmethod__, this is kept for backwards compat <=py3.12
+        return self.__partialmethod__
     
     @property
     def __partialmethod__(self):
-        # py3.13 switched from _partialmethod to __partialmethod__
-        return self._partialmethod
+        return functools.partialmethod(self.func, *self.args, **self.keywords)
 
     def __set_name__(self, obj_type, name):
         self.__name__ = name

--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -269,6 +269,11 @@ class CachedInstancePartial(functools.partial):
     @property
     def _partialmethod(self):
         return functools.partialmethod(self.func, *self.args, **self.keywords)
+    
+    @property
+    def __partialmethod__(self):
+        # py3.13 switched from _partialmethod to __partialmethod__
+        return self._partialmethod
 
     def __set_name__(self, obj_type, name):
         self.__name__ = name

--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -184,8 +184,6 @@ class _DeferredLine:
     def __init__(self, filename, lineno, module_globals=None):
         self.filename = filename
         self.lineno = lineno
-        # TODO: this is going away when we fix linecache
-        # TODO: (mark) read about loader
         if module_globals is None:
             self._mod_name = None
             self._mod_loader = None
@@ -660,7 +658,7 @@ def fix_print_exception():
     """
     Sets the default exception hook :func:`sys.excepthook` to the
     :func:`tbutils.print_exception` that uses all the ``tbutils``
-    facilities to provide slightly more correct output behavior.
+    facilities to provide a consistent output behavior.
     """
     sys.excepthook = print_exception
 
@@ -715,6 +713,12 @@ class ParsedException:
 
         ``ParsedException.from_string(text).to_string()`` should yield
         ``text``.
+
+        .. note::
+
+           Note that this method does not output "anchors" (e.g.,
+           ``~~~~~^^``), as were added in Python 3.13. See the built-in
+           ``traceback`` module if these are necessary.
         """
         lines = ['Traceback (most recent call last):']
 

--- a/tests/test_tbutils.py
+++ b/tests/test_tbutils.py
@@ -27,7 +27,7 @@ def test_exception_info():
     try:
         test()
     except:
-        _, _, exc_traceback = sys.exc_info()
+        exc, _, exc_traceback = sys.exc_info()
         tbi = TracebackInfo.from_traceback(exc_traceback)
         exc_info = ExceptionInfo.from_exc_info(*sys.exc_info())
         exc_info2 = ExceptionInfo.from_current()
@@ -53,7 +53,10 @@ def test_exception_info():
     assert "ValueError('yay fun')" in new_exc_hook_res
     assert len(new_exc_hook_res) > len(tbi_str)
 
-    assert new_exc_hook_res == builtin_exc_hook_res
+    if sys.version_info <= (3, 12):
+        # output diverges with Python 3.13+, see https://github.com/mahmoud/boltons/issues/365
+        # TLDR tbutils only has minimal handling for anchors (e.g., ~~~~^^)
+        assert new_exc_hook_res == builtin_exc_hook_res
 
 
 def test_contextual():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py39,py310,py311,py312,pypy3
+envlist = py37,py39,py310,py311,py312,py313,pypy3
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt


### PR DESCRIPTION
Kicked the can down the road (and documented as much) for anchors (`~~~~^^`) in `tbutils`, and fixed the move from `_partialmethod` to `__partialmethod__` in `funcutils`. This fixes #365.