### PR TITLE
Fix incorrect usage of lstrip bug in fileutils tests

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -57,7 +57,7 @@ __all__ = ['camel2under', 'under2camel', 'slugify', 'split_punct_ws',
            'iter_splitlines', 'indent', 'escape_shell_args',
            'args2cmd', 'args2sh', 'parse_int_list', 'format_int_list',
            'complement_int_list', 'int_ranges_from_int_list', 'MultiReplace',
-           'multi_replace', 'unwrap_text']
+           'multi_replace', 'unwrap_text', 'removeprefix']
 
 
 _punct_ws_str = string.punctuation + string.whitespace
@@ -1273,3 +1273,17 @@ def unwrap_text(text, ending='\n\n'):
     if ending is None:
         return all_grafs
     return ending.join(all_grafs)
+
+def removeprefix(text: str, prefix: str) -> str:
+    r"""
+    Remove `prefix` from start of `text` if present.
+
+    Backport of `str.removeprefix` for Python versions less than 3.9.
+
+    Args:
+        text: A string to remove the prefix from.
+        prefix: The string to remove from the beginning of `text`.
+    """
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -8,6 +8,7 @@ from boltons import fileutils
 from boltons.fileutils import FilePerms, iter_find_files
 
 
+# Directory of boltons source files (not ending with '/').
 BOLTONS_PATH = os.path.dirname(os.path.abspath(fileutils.__file__))
 
 
@@ -31,13 +32,13 @@ def test_fileperms():
 
 def test_iter_find_files():
     def _to_baseless_list(paths):
-        return [p.lstrip(BOLTONS_PATH) for p in paths]
+        return [p.removeprefix(BOLTONS_PATH) for p in paths]
 
-    assert 'fileutils.py' in _to_baseless_list(iter_find_files(BOLTONS_PATH, patterns=['*.py']))
+    assert '/fileutils.py' in _to_baseless_list(iter_find_files(BOLTONS_PATH, patterns=['*.py']))
 
     boltons_parent = os.path.dirname(BOLTONS_PATH)
-    assert 'fileutils.py' in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py']))
-    assert 'fileutils.py' not in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py'], max_depth=0))
+    assert '/fileutils.py' in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py']))
+    assert '/fileutils.py' not in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py'], max_depth=0))
 
 
 def test_rotate_file_no_rotation(tmp_path):

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -6,6 +6,7 @@ import os.path
 
 from boltons import fileutils
 from boltons.fileutils import FilePerms, iter_find_files
+from boltons.strutils import removeprefix
 
 
 # Directory of boltons source files (not ending with '/').
@@ -32,13 +33,13 @@ def test_fileperms():
 
 def test_iter_find_files():
     def _to_baseless_list(paths):
-        return [p.removeprefix(BOLTONS_PATH) for p in paths]
+        return [removeprefix(p, BOLTONS_PATH).lstrip(os.path.sep) for p in paths]
 
-    assert '/fileutils.py' in _to_baseless_list(iter_find_files(BOLTONS_PATH, patterns=['*.py']))
+    assert 'fileutils.py' in _to_baseless_list(iter_find_files(BOLTONS_PATH, patterns=['*.py']))
 
     boltons_parent = os.path.dirname(BOLTONS_PATH)
-    assert '/fileutils.py' in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py']))
-    assert '/fileutils.py' not in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py'], max_depth=0))
+    assert 'fileutils.py' in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py']))
+    assert 'fileutils.py' not in _to_baseless_list(iter_find_files(boltons_parent, patterns=['*.py'], max_depth=0))
 
 
 def test_rotate_file_no_rotation(tmp_path):

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -9,7 +9,6 @@ from boltons.fileutils import FilePerms, iter_find_files
 from boltons.strutils import removeprefix
 
 
-# Directory of boltons source files (not ending with '/').
 BOLTONS_PATH = os.path.dirname(os.path.abspath(fileutils.__file__))
 
 


### PR DESCRIPTION
I'm using Arch linux (typical starting statement of an arch user lol), and one of the packages I use depend on boltons (https://aur.archlinux.org/packages/python-boltons). I faced an issue with tests failing causing me to do some manual intervention.

On my machine, I have
```python
BOLTONS_PATH = "/home/theartful/.cache/yay/python-boltons/src/boltons/boltons"
```

The test checks that "fileutils.py" can be found using `iter_find_files`, and indeed it is part of `iter_find_files(BOLTONS_PATH, patterns=['*.py'])` as:
```python
p = "/home/theartful/.cache/yay/python-boltons/src/boltons/boltons/fileutils.py"
```

The bug here is that "lstrip" doesn't remove the prefix, but instead removes all characters from the left that is part of the string. For example:
```python
>>> BOLTONS_PATH = "/home/theartful/.cache/yay/python-boltons/src/boltons/boltons"
>>> p = "/home/theartful/.cache/yay/python-boltons/src/boltons/boltons/fileutils.py"
>>> p.lstrip(BOLTONS_PATH)
 ileutils.py
```