### PR TITLE
Fix Table.to_text() sizing

### DIFF
--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -569,7 +569,7 @@ class Table:
         text_data = [[to_text(cell, maxlen=maxlen) for cell in row]
                      for row in self._data]
         for idx in range(self._width):
-            cur_widths = [len(cur) for cur in text_data]
+            cur_widths = [len(row[idx]) for row in text_data]
             if with_headers:
                 cur_widths.append(len(to_text(headers[idx], maxlen=maxlen)))
             widths.append(max(cur_widths))


### PR DESCRIPTION
Table.to_text now measures column contents instead of row length when sizing the individual columns.

Before:
![image](https://github.com/user-attachments/assets/7fd6fc15-b269-4ec2-a2dc-a3264e89571e)

After:
![image](https://github.com/user-attachments/assets/d8ebe4f3-8d32-4e45-bacd-89b87a46cb66)
