### PR TITLE
feat(iterutils): Add coalesce: First non-none value

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -954,6 +954,28 @@ def first(iterable, default=None, key=None):
     return next(filter(key, iterable), default)
 
 
+def coalesce(*args):
+    """Get first non-none value
+
+    It behaves like `a_value if a_value is not None else default` allowing
+    `a_value` to be 0, empty string or any other falsy value.
+
+    >>> data = {"name": "Alice", "limit": 0, "value": ""}
+    >>> coalesce(data.get("name"), "Unknown")
+    'Alice'
+    >>> coalesce(data.get("limit"), 1)
+    0
+    >>> coalesce(data.get("value"), "default value")
+    ''
+    >>> coalesce(data.get("search"), {})
+    {}
+    >>> coalesce(data.get("search")) is None
+    True
+
+    """
+    return next((item for item in args if item is not None), None)
+
+
 def flatten_iter(iterable):
     """``flatten_iter()`` yields all the elements from *iterable* while
     collapsing any nested iterables.

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -12,7 +12,8 @@ from boltons.iterutils import (first,
                                research,
                                default_enter,
                                default_exit,
-                               get_path)
+                               get_path,
+                               coalesce)
 from boltons.namedutils import namedtuple
 
 CUR_PATH = os.path.abspath(__file__)
@@ -598,3 +599,26 @@ def test_windowed_filled():
 
     assert list(windowed_iter(range(4), 3)) == [(0, 1, 2), (1, 2, 3)]
     assert list(windowed_iter(range(4), 3, fill=None)) == [(0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
+
+
+a_dict = {"account_id": 1234, "a_string": "", "is_true": False, "a_number": 0, "a_none": None}
+
+
+@pytest.mark.parametrize(
+    "args, expected_output",
+    [
+        [(), None],
+        [(None,), None],
+        [(None, None), None],
+        [(None, 0), 0],
+        [(a_dict.get("account_id"), 0), 1234],
+        [(a_dict.get("a_string"), "default"), ""],
+        [(a_dict.get("is_true"), True), False],
+        [(a_dict.get("a_number"), 1), 0],
+        [(a_dict.get("a_none"), "default value"), "default value"],
+        [(a_dict.get("non_exitent"), "default value"), "default value"],
+    ],
+)
+def test_coalesce(args, expected_output):
+    actual = coalesce(*args)
+    assert actual == expected_output


### PR DESCRIPTION
Used when a valid value can be a _falsy_ value like `0`, ``""`` or `False`

Equivalent to `first(iterable, key=lambda x: x is not None)` but less verbose

Inspired in COALESCE function in SQL

```python
>>> coalesce(None, 0)
0
```