### PR TITLE
Fix barrellist sort with multiple lists

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -308,7 +308,7 @@ class BarrelList(list):
                 li.sort()
             tmp_sorted = sorted(chain.from_iterable(self.lists))
             del self.lists[:]
-            self.lists[0] = tmp_sorted
+            self.lists.append(tmp_sorted)
             self._balance_list(0)
 
     def reverse(self):

--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -51,6 +51,14 @@ def test_barrel_list():
     bl3[:20:2] = range(0, -10, -1)
     assert bl3[6] == -3  # some truly tricky stepping/slicing works
 
+def test_sort_barrel_list():
+    bl = BarrelList(reversed(range(100000)))
+    bl.pop(50000)
+    assert len(bl.lists) > 1
+    bl.sort()
+    assert bl[0] == 0
+    assert bl[-1] == 99999
+
 # roughly increasing random integers
 # [ord(i) * x for i, x in zip(os.urandom(1024), range(1024))]
 TEST_INTS = [0, 74, 96, 183, 456, 150, 1098, 665, 1752, 1053, 190,


### PR DESCRIPTION
The following code in `BarrelList.sort` causes a crash

```py
del self.lists[:]
self.lists[0] = tmp_sorted
```
