### PR TITLE
fix(tbutils): avoid IndexError in ParsedException.from_string on truncated tracebacks

### DIFF
--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -777,7 +777,7 @@ class ParsedException:
 
         frames = []
         line_no = start_line
-        while True:
+        while line_no < len(tb_lines):
             frame_line = tb_lines[line_no].strip()
             frame_match = frame_re.match(frame_line)
             if frame_match:
@@ -800,9 +800,10 @@ class ParsedException:
                 else:
                     frame_dict['source_line'] = next_line_stripped
                     line_no += 1
-                if _underline_re.match(tb_lines[line_no + 1]):
-                  # To deal with anchors
-                  line_no += 1
+                    if (line_no + 1 < len(tb_lines)
+                            and _underline_re.match(tb_lines[line_no + 1])):
+                        # To deal with anchors
+                        line_no += 1
             else:
                 break
             line_no += 1

--- a/tests/test_tbutils_parsed_exc.py
+++ b/tests/test_tbutils_parsed_exc.py
@@ -80,3 +80,21 @@ TypeError: unsupported operand type(s) for +: 'int' and 'str'"""
     _tb_str_lines = _tb_str.splitlines()
     _tb_str_without_anchor = "\n".join(_tb_str_lines[:3] + _tb_str_lines[4:6] + _tb_str_lines[7:])
     assert parsed_tb.to_string() == _tb_str_without_anchor
+
+
+def test_parsed_exc_truncated():
+    """a traceback whose last frame has a source line but no following
+    exception line should parse without raising IndexError"""
+    _tb_str = """\
+Traceback (most recent call last):
+  File "main.py", line 3, in <module>
+    print(add(1, 2))"""
+
+    parsed_tb = ParsedException.from_string(_tb_str)
+
+    assert parsed_tb.exc_type == ''
+    assert parsed_tb.exc_msg == ''
+    assert parsed_tb.frames == [{'source_line': 'print(add(1, 2))',
+                                 'filepath': 'main.py',
+                                 'lineno': '3',
+                                 'funcname': '<module>'}]


### PR DESCRIPTION
`ParsedException.from_string` raises `IndexError` when the last frame has a source line but no following line (a truncated traceback with no exception line). The anchor-handling added in #332 unconditionally reads `tb_lines[line_no + 1]`, which overruns the list.

```python
from boltons.tbutils import ParsedException
ParsedException.from_string('''Traceback (most recent call last):
  File "main.py", line 3, in <module>
    print(add(1, 2))''')
# IndexError: list index out of range
```

The anchor lookahead is now bounds-checked and only runs after a source line was consumed (anchors only follow source lines). The main loop also stops once the lines are exhausted instead of relying on an out-of-range access. Added a regression test; existing tbutils tests still pass.