### PR TITLE
Drop redundant len(self) call in BarrelList._balance_list

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -121,7 +121,7 @@ class BarrelList(list):
     def _balance_list(self, list_idx):
         if list_idx < 0:
             list_idx += len(self.lists)
-        cur_list, len_self = self.lists[list_idx], len(self)
+        cur_list = self.lists[list_idx]
         size_limit = self._cur_size_limit
         if len(cur_list) > size_limit:
             half_limit = size_limit // 2


### PR DESCRIPTION
### What

`BarrelList._balance_list` unpacks `len(self)` into a `len_self` local that is never read:

```python
def _balance_list(self, list_idx):
    if list_idx < 0:
        list_idx += len(self.lists)
    cur_list, len_self = self.lists[list_idx], len(self)   # len_self unused
    size_limit = self._cur_size_limit
    ...
```

This PR drops the unused assignment, keeping only `cur_list = self.lists[list_idx]`.

### Why

It's not just a stray variable. `BarrelList.__len__` is `sum([len(l) for l in self.lists])`, i.e. it scans every sublist. `_balance_list` is called on every mutation — `insert`, `append`, `__setitem__`, `pop`, etc. — so each of those operations was paying for a full-length scan whose result is immediately discarded. Removing it eliminates that avoidable work on the hot path while leaving behavior identical.

### Testing

- `pytest tests/test_listutils.py` — passes
- `pytest --doctest-modules boltons/listutils.py` — passes
- Full `pytest tests/` — passes (the only failure locally is `test_socketutils.py::test_basic_nonblocking`, a Windows-only non-blocking-socket quirk unrelated to this change)