### PR TITLE
Fix bytes2human rollover at exact powers of 1024

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -559,10 +559,12 @@ def bytes2human(nbytes, ndigits=0):
     '95M'
     >>> bytes2human(0, 2)
     '0.00B'
+    >>> bytes2human(1024)
+    '1K'
     """
     abs_bytes = abs(nbytes)
     for (size, symbol), (next_size, next_symbol) in _SIZE_RANGES:
-        if abs_bytes <= next_size:
+        if abs_bytes < next_size:
             break
     hnbytes = float(nbytes) / size
     return '{hnbytes:.{ndigits}f}{symbol}'.format(hnbytes=hnbytes,

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -252,3 +252,25 @@ def test_roundzip():
     assert strutils.gunzip_bytes(strutils.gzip_bytes(aaa)) == aaa
 
     assert strutils.gunzip_bytes(strutils.gzip_bytes(b'')) == b''
+
+
+def test_bytes2human():
+    b2h = strutils.bytes2human
+    # Exact powers of 1024 must roll over to the next unit, not show the
+    # previous unit times 1024.
+    assert b2h(1024) == '1K'
+    assert b2h(1024 ** 2) == '1M'
+    assert b2h(1024 ** 3) == '1G'
+    assert b2h(1024 ** 4) == '1T'
+    # Just below a boundary stays in the smaller unit.
+    assert b2h(1023) == '1023B'
+    assert b2h(1024 ** 2 - 1, 1) == '1024.0K'
+    # Ordinary mid-range values are unaffected.
+    assert b2h(0) == '0B'
+    assert b2h(2048) == '2K'
+    assert b2h(128991) == '126K'
+    # Sign is preserved and negative magnitudes scale like positives.
+    assert b2h(-1024) == '-1K'
+    assert b2h(-(1024 ** 2)) == '-1M'
+    # ndigits controls the fractional part.
+    assert b2h(1024, 2) == '1.00K'


### PR DESCRIPTION
## What

`bytes2human` doesn't roll over to the next unit at exact powers of 1024:

```python
>>> from boltons.strutils import bytes2human
>>> bytes2human(1024)        # expected '1K'
'1024B'
>>> bytes2human(1024 ** 2)   # expected '1M'
'1024K'
>>> bytes2human(1024 ** 3)   # expected '1G'
'1024M'
```

Sub-boundary values are fine (`bytes2human(1023) == '1023B'`, `bytes2human(2048) == '2K'`); only the exact boundaries are wrong.

## Why

The unit-selection loop compares the value against each boundary with `<=`:

```python
for (size, symbol), (next_size, next_symbol) in _SIZE_RANGES:
    if abs_bytes <= next_size:
        break
```

`_SIZE_RANGES` pairs each unit with the next one's threshold (`((1, 'B'), (1024, 'K'))`, …). When `abs_bytes` equals a threshold exactly (e.g. `1024`), `<=` breaks on the *smaller* unit, so the value renders as the previous unit × 1024. Using `<` lets exact boundaries advance to the next unit.

## Change

- `<=` → `<` in the boundary comparison (one character).
- Added a doctest (`bytes2human(1024) -> '1K'`) and a regression test in `tests/test_strutils.py` covering boundaries, sub-boundaries, mid-range, negatives and `ndigits`. The test was verified to fail on the current code and pass with the fix.

No behavior change for any non-boundary value. `pytest tests/` and `pytest --doctest-modules boltons/strutils.py` both pass. Happy to add a CHANGELOG entry in whatever form you prefer.
