### PR TITLE
Fix OrderedMultiDict equality to compare values against plain mappings

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -358,7 +358,8 @@ class OrderedMultiDict(dict):
         elif hasattr(other, 'keys'):
             for selfk in self:
                 try:
-                    other[selfk] == self[selfk]
+                    if other[selfk] != self[selfk]:
+                        return False
                 except KeyError:
                     return False
             return True

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -1264,7 +1264,8 @@ class OrderedMultiDict(dict):
         elif hasattr(other, 'keys'):
             for selfk in self:
                 try:
-                    other[selfk] == self[selfk]
+                    if other[selfk] != self[selfk]:
+                        return False
                 except KeyError:
                     return False
             return True

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -61,6 +61,20 @@ def test_eq():
     assert omd != omd3
 
 
+def test_eq_with_dict():
+    # OMD on the left dispatches to OMD.__eq__, which has to compare values
+    # against a plain mapping, not just keys.
+    omd = OMD([('a', 1), ('b', 2)])
+    assert omd == {'a': 1, 'b': 2}
+    assert not (omd != {'a': 1, 'b': 2})
+
+    assert omd != {'a': 999, 'b': 2}
+    assert not (omd == {'a': 999, 'b': 2})
+
+    # same number of keys but a different key
+    assert omd != {'a': 1, 'c': 2}
+
+
 def test_copy():
     for itemset in _ITEMSETS:
         omd = OMD(itemset)

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from boltons import urlutils
-from boltons.urlutils import URL, _URL_RE, find_all_links
+from boltons.urlutils import URL, QueryParamDict, _URL_RE, find_all_links
 
 
 # fully quoted urls that should round trip
@@ -93,6 +93,13 @@ def test_query_params(test_url):
         return 
     qp_text = url_obj.query_params.to_text(full_quote=True)
     assert test_url.endswith(qp_text)
+
+
+def test_query_param_dict_eq_with_dict():
+    qpd = QueryParamDict([('a', '1'), ('b', '2')])
+    assert qpd == {'a': '1', 'b': '2'}
+    assert qpd != {'a': '999', 'b': '2'}
+    assert not (qpd == {'a': '999', 'b': '2'})
 
 
 def test_iri_query():


### PR DESCRIPTION
OrderedMultiDict.__eq__ has a branch for comparing against a non-OMD mapping (anything with a keys() method, like a dict). That branch computes other[selfk] == self[selfk] but discards the result, so it only checks that every key of self exists in other and never compares the values. An OMD therefore compares equal to any same-keyed mapping no matter what the values are:

```python
>>> from boltons.dictutils import OMD
>>> omd = OMD([("a", 1), ("b", 2)])
>>> omd == {"a": 999, "b": 2}
True   # should be False
```

The existing test_eq does not catch this because its dict case is written as `d == omd`, which dispatches to `dict.__eq__` (OMD subclasses dict), not `OMD.__eq__`. The buggy branch is only reached with the OMD on the left.

Fix: compare the values and return False on mismatch. The length check earlier in __eq__ already handles the differing-key-count case.

The same __eq__ is duplicated in urlutils.OrderedMultiDict (the base class of QueryParamDict), which had the identical bug, so it is fixed there too.

Added regression tests in test_dictutils.py and test_urlutils.py that put the OMD/QueryParamDict on the left so the branch is actually exercised. Both fail before the change and pass after. Full suite: 433 passed.