### PR TITLE
Fix split_iter maxsplit=0 handling

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -158,7 +158,7 @@ def split_iter(src, sep=None, maxsplit=None):
     if maxsplit is not None:
         maxsplit = int(maxsplit)
         if maxsplit == 0:
-            yield [src]
+            yield list(src)
             return
 
     if callable(sep):

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -4,6 +4,7 @@ import pytest
 
 from boltons.dictutils import OMD
 from boltons.iterutils import (first,
+                               split,
                                pairwise,
                                pairwise_iter,
                                windowed,
@@ -22,6 +23,14 @@ isint = lambda x: isinstance(x, int)
 odd = lambda x: isint(x) and x % 2 != 0
 even = lambda x: isint(x) and x % 2 == 0
 is_meaning_of_life = lambda x: x == 42
+
+
+class TestSplit:
+    def test_maxsplit_zero_returns_unsplit_values(self):
+        values = [1, None, 2]
+
+        assert split(values, maxsplit=0) == [values]
+        assert split(iter(values), maxsplit=0) == [values]
 
 
 class TestFirst:
@@ -634,4 +643,3 @@ def test_partition_multiple():
     assert positive == [2, 3]
     assert negative == [-1, -2]
     assert zero == [0]
-


### PR DESCRIPTION
## Summary

Fix `split_iter(..., maxsplit=0)` so it yields the unsplit input values instead of wrapping the source iterable object itself.

Previously, the `maxsplit == 0` branch yielded `[src]`. For list inputs this produced an extra nested list, and for iterator inputs it returned the iterator object rather than its values.

## Validation

- Added a regression test covering both list and iterator inputs
- Confirmed the new test failed before the fix with `[[[1, None, 2]]] != [[1, None, 2]]`
- Ran `python -m pytest tests/test_iterutils.py::TestSplit::test_maxsplit_zero_returns_unsplit_values tests/test_iterutils.py -q` and confirmed 44 passed
- Ran `python -m pytest -q` and confirmed 436 passed