### PR TITLE
Match list insert before start in BarrelList

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -139,7 +139,7 @@ class BarrelList(list):
         else:
             list_idx, rel_idx = self._translate_index(index)
             if list_idx is None:
-                raise IndexError()
+                list_idx, rel_idx = 0, 0
             self.lists[list_idx].insert(rel_idx, item)
             self._balance_list(list_idx)
         return

--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -51,6 +51,17 @@ def test_barrel_list():
     bl3[:20:2] = range(0, -10, -1)
     assert bl3[6] == -3  # some truly tricky stepping/slicing works
 
+
+def test_barrel_list_insert_before_start_matches_list():
+    bl = BarrelList(range(int(1e5)))
+    bl._balance_list(0)
+
+    bl.insert(-int(1e9), 'start')
+
+    assert bl[0] == 'start'
+    assert len(bl) == int(1e5) + 1
+
+
 def test_sort_barrel_list():
     bl = BarrelList(reversed(range(100000)))
     bl.pop(50000)


### PR DESCRIPTION
## Summary

Make `BarrelList.insert()` match built-in `list.insert()` when the insertion index is before the start of a multi-bucket `BarrelList`.

`BarrelList` is documented as a `list` subtype with an identical API. Built-in lists clamp very negative insert indexes to the beginning, but `BarrelList` raised `IndexError` after it had been balanced into multiple internal lists.

## Validation

- Added a regression test for inserting with an index far below `-len(bl)` after balancing
- Confirmed the new test failed before the fix with `IndexError`
- Ran `python -m pytest tests/test_listutils.py::test_barrel_list_insert_before_start_matches_list tests/test_listutils.py -q` and confirmed 4 passed
- Ran `python -m pytest -q` and confirmed 436 passed