### PR TITLE
Remove listutils test import side effect

### DIFF
--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -89,8 +89,6 @@ TEST_INTS = [0, 74, 96, 183, 456, 150, 1098, 665, 1752, 1053, 190,
              21384, 40145, 26160, 46428, 30360]
 
 
-test_barrel_list()
-
 if __name__ == '__main__':
     _TUNE_SETUP = """\
 from boltons.listutils import BarrelList


### PR DESCRIPTION
## Summary

Remove the top-level `test_barrel_list()` call from `tests/test_listutils.py`.

Pytest already collects and runs `test_barrel_list` normally. Calling it at module import time makes collection/import execute the heavy test once before pytest runs the collected test, which adds an unnecessary side effect and duplicates work.

## Validation

- Confirmed `python -m pytest --collect-only -q tests/test_listutils.py` still collects `test_splay_list`, `test_barrel_list`, and `test_sort_barrel_list`
- Ran `python -m pytest tests/test_listutils.py -q` and confirmed 3 passed
- Ran `python -m pytest -q` and confirmed 435 passed