### PR TITLE
Speed up MultiReplace match lookup

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1214,9 +1214,7 @@ class MultiReplace:
 
     def _get_value(self, match):
         """Given a match object find replacement value."""
-        group_dict = match.groupdict()
-        key = [x for x in group_dict if group_dict[x]][0]
-        return self.group_map[key]
+        return self.group_map[match.lastgroup]
 
     def sub(self, text):
         """


### PR DESCRIPTION
## Summary

Use Match.lastgroup in MultiReplace._get_value() instead of building and scanning match.groupdict() for every replacement match.

MultiReplace compiles each replacement as a named group. The regex engine already exposes the matched group name through match.lastgroup, which avoids allocating a full group dict and scanning all groups per match.

## Benchmark

Benchmark script: 200 replacement patterns, 4,000 matches, mr.sub(text) repeated 20 times per sample.

- Before: best 4.975187s
- After: best 2.919870s
- Improvement: 1.70x faster / 41.3% lower best time

## Validation

- python -m pytest tests/test_strutils.py -q (17 passed)
- python -m pytest -q (435 passed)