### PR TITLE
Fix copy.copy/copy.deepcopy collapsing OrderedMultiDict values to one

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -180,6 +180,14 @@ class OrderedMultiDict(dict):
         self.clear()
         self.update_extend(state)
 
+    def __reduce__(self):
+        # The default dict-subclass reduce includes a dictitems iterator
+        # whose entries are reapplied via __setitem__ after __setstate__,
+        # collapsing each key's multiple values down to a single value.
+        # __getstate__/__setstate__ already round-trip the full (multi) state,
+        # so omit dictitems by returning a plain (callable, args, state) tuple.
+        return (self.__class__, (), self.__getstate__())
+
     def _clear_ll(self):
         try:
             _map = self._map

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -96,9 +96,32 @@ def test_omd_pickle():
 
     nonempty = OMD([('a', 1), ('b', 2), ('b', 3)])
 
-    roundtripped = pickle.loads(pickle.dumps(nonempty)) 
+    roundtripped = pickle.loads(pickle.dumps(nonempty))
     assert roundtripped == nonempty
     assert roundtripped.getlist('b') == [2, 3]
+
+
+def test_omd_copy_module():
+    # copy.copy / copy.deepcopy must preserve multiple values per key. The
+    # inherited dict __reduce_ex__ used to reapply a dictitems iterator after
+    # __setstate__, collapsing each key down to a single value.
+    import copy
+
+    omd = OMD([('a', 1), ('a', 2), ('b', 3)])
+
+    shallow = copy.copy(omd)
+    assert shallow == omd
+    assert shallow.getlist('a') == [1, 2]
+
+    deep = copy.deepcopy(omd)
+    assert deep == omd
+    assert deep.getlist('a') == [1, 2]
+
+    # deepcopy must not share mutable values with the original
+    nested = OMD([('x', [1]), ('x', [2])])
+    nested_copy = copy.deepcopy(nested)
+    nested_copy.getlist('x')[0].append(99)
+    assert nested.getlist('x') == [[1], [2]]
 
 
 


### PR DESCRIPTION
## Steps

`copy.copy` and `copy.deepcopy` silently collapse an `OrderedMultiDict`'s multiple values per key down to a single value:

```python
from boltons.dictutils import OrderedMultiDict as OMD
import copy
o = OMD([('a', 1), ('a', 2)])
copy.deepcopy(o)            # OMD([('a', 2)])  -- lost ('a', 1)
copy.deepcopy(o) == o       # False
copy.copy(o) == o           # False
```

`pickle` round-trips correctly; only the `copy` module is affected.

## Cause

`OrderedMultiDict` subclasses `dict`, so the inherited `__reduce_ex__` emits a 5-tuple whose `dictitems` element is an iterator over the *underlying* `{key: [values]}` dict. In `copy._reconstruct`, after `__setstate__` has already rebuilt the full multidict, that `dictitems` iterator is replayed via `__setitem__` (`y['a'] = [1, 2]`), which wipes the internal linked list and replaces each key's values with a single value.

`__getstate__`/`__setstate__` already round-trip the complete multi-value state — which is why `pickle` (different setitems/setstate ordering) was unaffected — so the `dictitems` element is both redundant and actively harmful here.

## Fix

Add `__reduce__` returning a plain `(self.__class__, (), self.__getstate__())` tuple, omitting `dictitems`. Reconstruction now goes purely through `__setstate__`.

`copy.copy`, `copy.deepcopy`, and `pickle` (protocols 0–5) now all preserve every value; deepcopy independence is kept (mutating a copied value doesn't affect the original) and shallow copy still shares. Added a regression test (`test_omd_copy_module`); full suite passes (438).

## Notes

Found by fuzzing the copy/pickle round-trip. This pull request was prepared with the assistance of AI, under my direction and review.
