### PR TITLE
tbutils: preserve ParsedException anchor lines

### DIFF
--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -716,9 +716,9 @@ class ParsedException:
 
         .. note::
 
-           Note that this method does not output "anchors" (e.g.,
-           ``~~~~~^^``), as were added in Python 3.13. See the built-in
-           ``traceback`` module if these are necessary.
+           Note that this method stores traceback anchor lines (e.g.,
+           ``~~~~~^^``), but does not store SyntaxError details as
+           structured fields.
         """
         lines = ['Traceback (most recent call last):']
 
@@ -729,6 +729,9 @@ class ParsedException:
             source_line = frame.get('source_line')
             if source_line:
                 lines.append(f'    {source_line}')
+                source_line_anchor = frame.get('source_line_anchor')
+                if source_line_anchor:
+                    lines.append(f'    {source_line_anchor}')
         if self.exc_msg:
             lines.append(f'{self.exc_type}: {self.exc_msg}')
         else:
@@ -798,11 +801,13 @@ class ParsedException:
                 ):
                     frame_dict['source_line'] = ''
                 else:
-                    frame_dict['source_line'] = next_line_stripped
+                    frame_dict['source_line'] = next_line[4:]
                     line_no += 1
                     if (line_no + 1 < len(tb_lines)
                             and _underline_re.match(tb_lines[line_no + 1])):
-                        # To deal with anchors
+                        frame_dict['source_line_anchor'] = tb_lines[
+                            line_no + 1
+                        ][4:]
                         line_no += 1
             else:
                 break

--- a/tests/test_tbutils_parsed_exc.py
+++ b/tests/test_tbutils_parsed_exc.py
@@ -67,19 +67,23 @@ TypeError: unsupported operand type(s) for +: 'int' and 'str'"""
 
     assert parsed_tb.exc_type == 'TypeError'
     assert parsed_tb.exc_msg == "unsupported operand type(s) for +: 'int' and 'str'"
-    assert parsed_tb.frames == [{'source_line': 'print(add(1, "two"))',
-                                  'filepath': 'main.py',
-                                  'lineno': '3',
-                                  'funcname': '<module>'},
-                                  {'source_line': 'return a + b',
-                                  'filepath': 'add.py',
-                                  'lineno': '2',
-                                  'funcname': 'add'}]
-    
-    # Note: not checking the anchor lines (indices 3, 6) because column details not currently stored in ParsedException
-    _tb_str_lines = _tb_str.splitlines()
-    _tb_str_without_anchor = "\n".join(_tb_str_lines[:3] + _tb_str_lines[4:6] + _tb_str_lines[7:])
-    assert parsed_tb.to_string() == _tb_str_without_anchor
+    assert parsed_tb.frames == [
+        {
+            'source_line': 'print(add(1, "two"))',
+            'source_line_anchor': '      ^^^^^^^^^^^^^',
+            'filepath': 'main.py',
+            'lineno': '3',
+            'funcname': '<module>',
+        },
+        {
+            'source_line': 'return a + b',
+            'source_line_anchor': '       ~~^~~',
+            'filepath': 'add.py',
+            'lineno': '2',
+            'funcname': 'add',
+        },
+    ]
+    assert parsed_tb.to_string() == _tb_str
 
 
 def test_parsed_exc_truncated():


### PR DESCRIPTION
## Summary
- store traceback source anchor lines on parsed frames as `source_line_anchor`
- emit stored anchors from `ParsedException.to_string()`
- update the anchor regression test to assert exact `from_string(...).to_string()` round-tripping

Closes #333.

## Validation
- `python -m pytest tests/test_tbutils_parsed_exc.py::test_parsed_exc_with_anchor -q`
- `python -m pytest tests/test_tbutils_parsed_exc.py tests/test_tbutils.py -q`
- `python -m pytest -q` (437 passed)
- `python -m compileall boltons/tbutils.py tests/test_tbutils_parsed_exc.py`
- `git diff --check`

This pull request was prepared with the assistance of AI, under my direction and review.