### PR TITLE
funcutils: forward defaulted args as keyword args in wraps invocation

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -790,23 +790,28 @@ class FunctionBuilder:
     """, re.VERBOSE)
 
     def get_invocation_str(self):
-        kwonly_pairs = None
-        formatters = {}
-        if self.kwonlyargs:
-            kwonly_pairs = {arg: arg
-                                for arg in self.kwonlyargs}
-            formatters['formatvalue'] = lambda value: '=' + value
+        # Build the invocation string that forwards all arguments to _call.
+        # Regular args that have defaults must be forwarded as keyword
+        # arguments (``name=name``) so that callers who supply them by
+        # keyword have those values arrive in *kwargs* inside the wrapper,
+        # not silently flattened into a positional tuple.  Without this,
+        # ``wrapper(*args, **kwargs)`` loses keyword information for
+        # defaulted parameters (issue #343).
+        defaults = self.defaults or ()
+        n_positional = len(self.args) - len(defaults)
+        positional_args = self.args[:n_positional]
+        defaulted_args = self.args[n_positional:]
 
-        sig = inspect_formatargspec(self.args,
-                                    self.varargs,
-                                    self.varkw,
-                                    [],
-                                    kwonly_pairs,
-                                    kwonly_pairs,
-                                    {},
-                                    **formatters)
-        sig = self._KWONLY_MARKER.sub('', sig)
-        return sig[1:-1]
+        parts = list(positional_args)
+        if self.varargs:
+            parts.append('*' + self.varargs)
+        for arg in defaulted_args:
+            parts.append(arg + '=' + arg)
+        for arg in (self.kwonlyargs or []):
+            parts.append(arg + '=' + arg)
+        if self.varkw:
+            parts.append('**' + self.varkw)
+        return ', '.join(parts)
 
     @classmethod
     def from_func(cls, func):

--- a/tests/test_funcutils.py
+++ b/tests/test_funcutils.py
@@ -6,7 +6,8 @@ from boltons.funcutils import (copy_function,
                                InstancePartial,
                                CachedInstancePartial,
                                noop,
-                               once)
+                               once,
+                               wraps)
 
 
 class Greeter:
@@ -80,6 +81,34 @@ def test_format_invocation():
     assert format_invocation('f', ('a', 'b')) == "f('a', 'b')"
     assert format_invocation('g', (), {'x': 'y'})  == "g(x='y')"
     assert format_invocation('h', ('a', 'b'), {'x': 'y', 'z': 'zz'}) == "h('a', 'b', x='y', z='zz')"
+
+def test_wraps_preserves_kwargs_for_defaulted_args():
+    """wraps must not collapse keyword args into positional args (issue #343).
+
+    When a caller passes a defaulted parameter by keyword, the generated
+    invocation must forward it as a keyword argument so that wrappers
+    that inspect *args and **kwargs see the value in the right place.
+    """
+    def flip(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*reversed(args), **kwargs)
+        return wrapper
+
+    def power(x, y, msg=''):
+        return (x, y, msg)
+
+    flipped = flip(power)
+
+    # keyword arg must stay in kwargs, not bleed into args
+    assert flipped(3, 2, msg='abc') == (2, 3, 'abc')
+    # positional-only call still works
+    assert flipped(3, 2) == (2, 3, '')
+    # passing the defaulted arg positionally: the generated wrapper binds it
+    # as msg='pos' then forwards msg=msg (keyword), so the inner wrapper sees
+    # args=(3, 2) and kwargs={'msg': 'pos'}; reversed args only affects x and y
+    assert flipped(3, 2, 'pos') == (2, 3, 'pos')
+
 
 def test_noop():
     assert noop() is None

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -235,7 +235,8 @@ def test_wraps_expected():
     def expect_pair(func):
         @wraps(func, expected=[('c', 5)])
         def wrapped(*args, **kwargs):
-            args, c = args[:2], args[-1]
+            # defaulted args are now forwarded as keyword args; extract from kwargs
+            c = kwargs.pop('c', 5)
             return func(*args, **kwargs) + (c,)
         return wrapped
 
@@ -244,7 +245,8 @@ def test_wraps_expected():
     def expect_dict(func):
         @wraps(func, expected={'c': 6})
         def wrapped(*args, **kwargs):
-            args, c = args[:2], args[-1]
+            # defaulted args are now forwarded as keyword args; extract from kwargs
+            c = kwargs.pop('c', 6)
             return func(*args, **kwargs) + (c,)
         return wrapped
 
@@ -277,7 +279,7 @@ def test_get_arg_names():
     [
         (["a", "b"], None, None, None, "a, b", "(a, b)"),
         (None, "args", "kwargs", None, "*args, **kwargs", "(*args, **kwargs)"),
-        ("a", None, None, dict(a="a"), "a", "(a)"),
+        ("a", None, None, dict(a="a"), "a=a", "(a)"),
     ],
 )
 def test_get_invocation_sig_str(

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -217,22 +217,12 @@ def test_get_invocation_sig_str(
 def test_wraps_inner_kwarg_only():
     """from https://github.com/mahmoud/boltons/issues/261
 
-    mh responds to the issue:
-
-    You'll notice that when kw-only args are involved the first time
-    (wraps(f)(g)) it works fine. The other way around, however,
-    wraps(g)(f) fails, because by the very nature of funcutils.wraps,
-    you're trying to give f the same signature as g. And f's signature
-    is not like g's. g supports positional b and f() does not.
-
-    If you want to make a wrapper which converts a keyword-only
-    argument to one that can be positional or keyword only, that'll
-    require a different approach for now.
-
-    A potential fix would be to pass all function arguments as
-    keywords. But doubt that's the right direction, because, while I
-    have yet to add positional argument only support, that'll
-    definitely throw a wrench into things.
+    wraps(g)(f) where g has a positional-or-keyword defaulted arg (b=10)
+    and f has the same arg as keyword-only (*, b=1).  Previously this
+    raised TypeError because the generated invocation passed b
+    positionally, violating f's keyword-only constraint.  After fixing
+    get_invocation_str to forward defaulted args as ``b=b``, the call
+    goes through correctly.
     """
     from boltons.funcutils import wraps
 
@@ -247,9 +237,9 @@ def test_wraps_inner_kwarg_only():
     assert g(3) == 30
     assert wraps(f)(g)(3) == 3  # yay, g got the f default (not so with functools.wraps!)
 
-    # but this doesn't work
-    with pytest.raises(TypeError):
-        wraps(g)(f)(3)
+    # wraps(g)(f) gives f the signature of g (positional b).  The generated
+    # invocation now passes b as a keyword arg, which is accepted by f.
+    assert wraps(g)(f)(3) == 30  # uses g's default b=10
 
     return
 


### PR DESCRIPTION
Fixes #343.

## The bug

`FunctionBuilder.get_invocation_str()` passes every regular argument
positionally in the generated body:

```python
# generated for:  def pow(x, y, msg=''):
return _call(x, y, msg)
```

When a caller supplies a defaulted parameter by keyword (`pow(3, 2, msg='abc')`),
the generated function correctly binds `msg='abc'`, but then forwards it
positionally as `_call(3, 2, 'abc')`.  Any wrapper that inspects
`*args` / `**kwargs` separately—the standard pattern—loses the keyword
information:

```python
def flip(f):
    @wraps(f)
    def wrapper(*args, **kwargs):
        return f(*reversed(args), **kwargs)
    return wrapper

def power(x, y, msg=''):
    return (x, y, msg)

flip(power)(3, 2, msg='abc')
# before: ('abc', 2, 3)  – msg landed in args, was reversed
# after:  (2, 3, 'abc')  – correct
```

## The fix

Args that carry a default are now forwarded with the `name=name` form:

```python
return _call(x, y, msg=msg)
```

This means the inner wrapper receives them in `**kwargs`, preserving
exactly how the caller passed them.

As a welcome side-effect, this also lifts the limitation documented in
`test_wraps_inner_kwarg_only` (issue #261): wrapping a keyword-only-`b`
function with a signature that exposes `b` as positional-or-keyword now
works, because the generated invocation passes `b=b`.

## Test changes

- Added `test_wraps_preserves_kwargs_for_defaulted_args` in
  `test_funcutils.py` directly covering the issue #343 scenario.
- `test_wraps_inner_kwarg_only`: updated docstring and assertion to
  reflect that `wraps(g)(f)(3)` now succeeds (was asserting `TypeError`
  which documented the old limitation).
- `test_wraps_expected` (`expect_pair` / `expect_dict`): these wrappers
  extracted defaulted injected args from `args[-1]`, relying on the old
  positional-passthrough. Updated to use `kwargs.pop(...)`, which is the
  correct pattern under the new semantics.
- Parametrized `test_get_invocation_sig_str`: updated expected invocation
  string for the single-defaulted-arg case (`"a"` → `"a=a"`).

All 438 tests pass.