### PR TITLE
Handle bytes from socket.gethostname() in GUIDerator.reseed

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -1475,8 +1475,13 @@ class GUIDerator:
     def reseed(self):
         import socket
         self.pid = os.getpid()
+        hostname = socket.gethostname()
+        # gethostname() may return bytes on some platforms/configs; decode so
+        # the str.join() below does not raise a TypeError on a mixed sequence.
+        if isinstance(hostname, bytes):
+            hostname = hostname.decode('utf8', 'replace')
         self.salt = '-'.join([str(self.pid),
-                              socket.gethostname() or '<nohostname>',
+                              hostname or '<nohostname>',
                               str(time.time()),
                               os.urandom(6).hex()])
         return

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -535,6 +535,21 @@ def test_guiderator():
     assert len(next(guid_iter)) == 26
 
 
+def test_guiderator_bytes_hostname(monkeypatch):
+    # socket.gethostname() may return bytes on some platforms; reseed() must
+    # not raise a TypeError when building the salt (issue #295).
+    import socket
+    import string
+    from boltons.iterutils import GUIDerator
+
+    monkeypatch.setattr(socket, 'gethostname', lambda: b'myhost')
+
+    guid_iter = GUIDerator()
+    guid = next(guid_iter)
+    assert guid
+    assert all([c in string.hexdigits for c in guid])
+
+
 def test_seqguiderator():
     import string
     from boltons.iterutils import SequentialGUIDerator as GUIDerator


### PR DESCRIPTION
## Summary
Closes #295.

On some platforms/configurations `socket.gethostname()` returns `bytes` rather than `str`. `GUIDerator.reseed()` joins it into the salt with `str.join()`:

```python
self.salt = '-'.join([str(self.pid),
                      socket.gethostname() or '<nohostname>',
                      ...])
```

which raises `TypeError: sequence item 1: expected str instance, bytes found`. Because a module-level `GUIDerator()` is created at import time, this can break importing `boltons.iterutils` entirely on affected systems.

## Fix
Decode the hostname to `str` when it comes back as `bytes`:

```python
hostname = socket.gethostname()
if isinstance(hostname, bytes):
    hostname = hostname.decode('utf8', 'replace')
```

## Tests
Added `test_guiderator_bytes_hostname` (monkeypatches `socket.gethostname` to return `b'myhost'`) asserting a valid hex GUID is produced without raising.

Verified locally: `pytest tests/test_iterutils.py` → **45 passed**.