### PR TITLE
Fix IndexedSet.__getitem__ wrapping out-of-range negative indices

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -412,6 +412,11 @@ class IndexedSet(MutableSet):
             return self.from_iterable(iter_slice)
         if index < 0:
             index += len(self)
+        if not 0 <= index < len(self):
+            # _get_real_index() normalizes negative indices a second time, so
+            # an out-of-range negative index would otherwise wrap around and
+            # return the wrong item instead of raising (list semantics).
+            raise IndexError('IndexedSet index out of range')
         real_index = self._get_real_index(index)
         try:
             ret = self.item_list[real_index]

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -203,3 +203,30 @@ def test_iset_index_method():
         if i % 3:
             index = indexed_list.index(i)
             assert i == indexed_list.pop(index)
+
+
+def test_indexed_set_getitem_out_of_range():
+    # Integer indexing must match list semantics: an out-of-range index raises
+    # IndexError. Regression for __getitem__ silently wrapping out-of-range
+    # negative indices (they were normalized twice) instead of raising.
+    ref = [10, 20, 30]
+    iset = IndexedSet(ref)
+
+    for i in range(-len(ref), len(ref)):
+        assert iset[i] == ref[i]
+
+    for bad in (3, 4, 100, -4, -5, -7, -100):
+        with raises(IndexError):
+            iset[bad]
+
+    # The mapping from logical to real index must stay correct once internal
+    # dead markers exist (discard() leaves holes in the backing list).
+    big = IndexedSet(range(10))
+    big.discard(0)
+    big.discard(5)
+    live = [1, 2, 3, 4, 6, 7, 8, 9]
+    for i in range(-len(live), len(live)):
+        assert big[i] == live[i]
+    for bad in (len(live), -len(live) - 1):
+        with raises(IndexError):
+            big[bad]


### PR DESCRIPTION
### The bug

An out-of-range **negative** integer index into an `IndexedSet` silently wraps around and returns the wrong element instead of raising `IndexError`:

```python
>>> from boltons.setutils import IndexedSet
>>> IndexedSet([10, 20, 30])[-4]
30          # expected: IndexError
>>> IndexedSet([10, 20, 30])[-5]
20          # expected: IndexError
```

A real `list` raises `IndexError` here, and `IndexedSet` documents itself as `list`-like ("supports indexing and slicing", "as complete a union of the `list` and `set` APIs as possible"). It is also internally inconsistent: the *positive* out-of-range path already raises (`IndexedSet([10, 20, 30])[3]` → `IndexError`); only the negative side wraps.

### Root cause

`IndexedSet.__getitem__` normalizes a negative index by adding `len(self)`, then calls `_get_real_index()`, which adds `len(self)` **again**:

```python
# __getitem__
if index < 0:
    index += len(self)
real_index = self._get_real_index(index)   # _get_real_index also does `if index < 0: index += len(self)`
```

For `[-4]` on a length-3 set: `-4 → -1` (first add), then `_get_real_index(-1) → 2` (second add), so `item_list[2]` returns `30`. The double-shifted value stays a valid (wrapping) Python list index, so the existing `try/except IndexError` never fires.

### Fix

Bounds-check the normalized logical index before the second normalization:

```python
if index < 0:
    index += len(self)
if not 0 <= index < len(self):
    raise IndexError('IndexedSet index out of range')
```

After the guard, `index` is in `[0, len)`, so `_get_real_index()`'s own negative branch is a no-op (no double-add) and the dead-marker remapping is unaffected.

### Tests

Added `test_indexed_set_getitem_out_of_range`: every in-range index agrees with a `list` reference, out-of-range indices on **both** sides raise `IndexError`, and the logical→real mapping stays correct after `discard()` introduces internal dead markers. The test fails on `master` (`DID NOT RAISE IndexError` at `[-4]`) and passes with the fix; the full suite goes 437 → 438 passing.
