### PR TITLE
fix(fileutils): accept os.PathLike in AtomicSaver

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -386,7 +386,7 @@ class AtomicSaver:
 
     # TODO: option to abort if target file modify date has changed since start?
     def __init__(self, dest_path, **kwargs):
-        self.dest_path = dest_path
+        self.dest_path = os.fspath(dest_path)
         self.overwrite = kwargs.pop('overwrite', True)
         self.file_perms = kwargs.pop('file_perms', None)
         self.overwrite_part = kwargs.pop('overwrite_part', False)
@@ -400,7 +400,7 @@ class AtomicSaver:
         self.dest_path = os.path.abspath(self.dest_path)
         self.dest_dir = os.path.dirname(self.dest_path)
         if not self.part_filename:
-            self.part_path = dest_path + '.part'
+            self.part_path = self.dest_path + '.part'
         else:
             self.part_path = os.path.join(self.dest_dir, self.part_filename)
         self.mode = 'w+' if self.text_mode else 'w+b'
@@ -530,6 +530,7 @@ def iter_find_files(directory, patterns, ignored=None, include_dirs=False, max_d
     elif isinstance(ignored, str):
         ignored = [ignored]
     ign_re = re.compile('|'.join([fnmatch.translate(p) for p in ignored]))
+    directory = os.fspath(directory)
     start_depth = len(directory.split(os.path.sep))
     for root, dirs, files in os.walk(directory):
         if max_depth is not None and (len(root.split(os.path.sep)) - start_depth) > max_depth:

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,6 +1,5 @@
 import os.path
-
-
+import pathlib
 
 
 
@@ -28,6 +27,20 @@ def test_fileperms():
     assert oct(int(up)) == '0o770'
 
     assert int(FilePerms()) == 0
+
+
+def test_atomicsaver_pathlike(tmp_path):
+    dest = tmp_path / 'output.bin'
+    with fileutils.AtomicSaver(dest) as f:
+        f.write(b'pathlike works')
+    assert dest.read_bytes() == b'pathlike works'
+
+
+def test_iter_find_files_pathlike():
+    boltons_path = pathlib.Path(BOLTONS_PATH)
+    results = list(iter_find_files(boltons_path, patterns=['*.py']))
+    basenames = [os.path.basename(p) for p in results]
+    assert 'fileutils.py' in basenames
 
 
 def test_iter_find_files():


### PR DESCRIPTION
`AtomicSaver.__init__` assigned `dest_path` directly to `self.dest_path` and later concatenated it as a string (`dest_path + '.part'`), which raises `TypeError` when a `pathlib.Path` is passed.

`iter_find_files` called `.split()` on the `directory` argument, which also fails for `pathlib.Path`.

**Changes:**
- `AtomicSaver.__init__`: convert `dest_path` via `os.fspath()` at the top of the method, and use `self.dest_path` (the already-converted str) when building the `.part` path
- `iter_find_files`: convert `directory` via `os.fspath()` before calling `.split()`
- Add `test_atomicsaver_pathlike` and `test_iter_find_files_pathlike` to the test suite

Closes #383