### PR TITLE
fix: handle unencoded ? and / in URL credentials in parse_url()

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -917,6 +917,29 @@ def parse_url(url_text):
         if sep:
             # TODO: empty userinfo error?
             user, _, pw = userinfo.partition(':')
+        else:
+            # No '@' found in authority. This can happen when the password
+            # contains an unencoded '?' or '/', causing the URL regex to stop
+            # the authority capture early and absorb the '@' into the query
+            # or path instead. Recover by detecting '@' at the start of
+            # the query (unencoded '?') or after '/' at the start of the
+            # path (unencoded '/'), then reconstruct userinfo and hostinfo.
+            query_text = gs.get('query') or ''
+            path_text = gs.get('path') or ''
+            if query_text.startswith('@'):
+                # Unencoded '?' in password: the regex treated '?' as the
+                # query delimiter and '@' landed at the start of the query.
+                userinfo = au_text + '?'
+                hostinfo = query_text[1:]
+                gs['query'] = None
+                user, _, pw = userinfo.partition(':')
+            elif path_text.startswith('/@'):
+                # Unencoded '/' in password: the regex treated '/' as the
+                # path start and '@' landed immediately after in the path.
+                userinfo = au_text + '/'
+                hostinfo = path_text[2:]
+                gs['path'] = ''
+                user, _, pw = userinfo.partition(':')
 
     host, port = None, None
     if hostinfo:


### PR DESCRIPTION
Fixes #309

When a URL password contains an unencoded `?` or `/`, the URL regex stops the authority capture early (at the special character), absorbing the `@` credential separator into the query or path instead.

**Root cause:** The regex `[^/?#]*` for the authority group halts at `?`, `/`, or `#`. So `http://user:p?ss@host:443` is parsed as authority=`user:p`, query=`ss@host:443` — and then `parse_url()` finds no `@` in the authority and fails when it tries to parse `p` as a port.

**Fix:** After the normal `rpartition('@')` finds no `@` in the authority, detect two recovery cases:
- `query.startswith('@')` → the password had an unencoded `?`; reconstruct `userinfo = authority + '?'` and `hostinfo = query[1:]`
- `path.startswith('/@')` → the password had an unencoded `/`; reconstruct `userinfo = authority + '/'` and `hostinfo = path[2:]`

**Note:** Per RFC 3986, special characters in credentials should be percent-encoded (`?` → `%3F`, `/` → `%2F`). This fix makes boltons tolerant of the common real-world case where they are not.