### PR TITLE
fix(strutils): stop singularize() mangling words ending in 'ss'

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -227,6 +227,13 @@ def singularize(word):
         singular = word[:-3] + 'y'
     elif word.endswith('es') and word[-3] == 's':
         singular = word[:-2]
+    elif word.endswith('ss'):
+        # Words ending in a double 's' (glass, boss, kiss) are already
+        # singular; their plurals end in 'sses' and are handled above. Do
+        # not blindly strip the trailing 's', which would produce 'glas',
+        # 'bos', 'kis' and break idempotency (singularize('Glasses') ==
+        # 'Glass', but 'Glass' must stay 'Glass').
+        return orig_word
     else:
         singular = word[:-1]
     return _match_case(orig_word, singular)

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -274,3 +274,28 @@ def test_bytes2human():
     assert b2h(-(1024 ** 2)) == '-1M'
     # ndigits controls the fractional part.
     assert b2h(1024, 2) == '1.00K'
+
+
+def test_singularize_double_s():
+    singularize = strutils.singularize
+    # Words ending in a double 's' are already singular (their plurals end
+    # in 'sses'), so singularize must not strip the trailing 's' and produce
+    # 'glas'/'bos'/'kis'. Regression for the branch that blindly did word[:-1].
+    assert singularize('glass') == 'glass'
+    assert singularize('boss') == 'boss'
+    assert singularize('class') == 'class'
+    assert singularize('kiss') == 'kiss'
+    assert singularize('address') == 'address'
+    assert singularize('business') == 'business'
+    # Case pattern is preserved, like the rest of singularize().
+    assert singularize('Glass') == 'Glass'
+    assert singularize('BOSS') == 'BOSS'
+    # The real plurals of these words still singularize correctly (the 'sses'
+    # -> 'ss' branch runs before the new guard, so nothing regresses).
+    assert singularize('glasses') == 'glass'
+    assert singularize('bosses') == 'boss'
+    assert singularize('classes') == 'class'
+    assert singularize('addresses') == 'address'
+    # singularize() is now idempotent for these words: feeding its own output
+    # back in is a no-op (previously 'Glasses' -> 'Glass' -> 'Glas').
+    assert singularize(singularize('Glasses')) == 'Glass'


### PR DESCRIPTION
## Summary

`strutils.singularize()` corrupts words that are already singular and end in a double `s` (`glass`, `boss`, `class`, `kiss`, `address`, `business`, ...), returning `glas`, `bos`, `clas`, `kis`, `addres`, `busines`.

```python
>>> from boltons.strutils import singularize
>>> singularize('glass')
'glas'      # expected 'glass'
>>> singularize('boss')
'bos'       # expected 'boss'
>>> singularize('address')
'addres'    # expected 'address'
```

## Root cause

`singularize()` ends with a catch-all that strips the final character from any word ending in `s` that didn't match the `-ies` / `-ses` branches:

```python
elif word.endswith('es') and word[-3] == 's':
    singular = word[:-2]
else:
    singular = word[:-1]      # <-- 'glass' -> 'glas'
```

No English plural ends in `ss`. The plural of these words ends in `sses` (`glass` -> `glasses`), which is **already** handled correctly by the preceding `word.endswith('es') and word[-3] == 's'` branch. Only words that are *already singular* and end in `ss` fall through to the blind `word[:-1]`.

This also violated the idempotency implied by the function's own docstring (`singularize('Glasses') == 'Glass'`): feeding that canonical singular back in produced `'Glas'`, and applying `singularize()` defensively to an already-singular word degraded it further (`'boss'` -> `'bos'` -> `'bo'`).

## Fix

Add an `elif word.endswith('ss')` guard before the final fallback that returns the word unchanged (+7 lines). Because the `-sses` branch runs first, real plurals are unaffected.

## Before / after

| input | before | after |
|-------|--------|-------|
| `glass` | `glas` | `glass` |
| `boss` | `bos` | `boss` |
| `class` | `clas` | `class` |
| `kiss` | `kis` | `kiss` |
| `address` | `addres` | `address` |
| `business` | `busines` | `business` |
| `glasses` (plural) | `glass` | `glass` *(unchanged)* |
| `bosses` (plural) | `boss` | `boss` *(unchanged)* |
| `chances`, `cats`, `activities` | correct | correct *(unchanged)* |

The single-`s` ambiguous cases (e.g. `bus`) are intentionally left alone — they are indistinguishable from a regular plural (`cats` -> `cat`) without a dictionary, so this PR does not touch them.

## Tests

Added `test_singularize_double_s` covering the double-`s` singular words, case preservation (`Glass`, `BOSS`), the still-correct `-sses` plurals, and idempotency.

Proven to guard the bug (regression test fails on unpatched source, passes with the fix):

```
# source fix stashed, test kept:
>   assert singularize('glass') == 'glass'
E   AssertionError: assert 'glas' == 'glass'
1 failed

# fix restored:
1 passed
```

Full suite: **438 passed** (was 437). All 28 `strutils` docstring doctests pass. No linter is configured in CI; the change is pure stdlib control flow valid on every supported Python (3.7-3.14).
