### PR TITLE
fix(urlutils): QueryParamDict equality ignores key insertion order

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -1586,6 +1586,32 @@ class QueryParamDict(OrderedMultiDict):
         pairs = parse_qsl(query_string, keep_blank_values=True)
         return cls(pairs)
 
+    def __eq__(self, other):
+        """Compare two :class:`QueryParamDict` instances in a key-order-independent
+        way.
+
+        Two query param dicts are equal when they contain the same keys and,
+        for each key, the same list of values in the same order.  The
+        insertion order of *different* keys does not affect equality, which
+        matches the behaviour described in RFC 3986 §6.2.3.
+
+        >>> QueryParamDict.from_text('a=1&b=2') == QueryParamDict.from_text('b=2&a=1')
+        True
+        >>> QueryParamDict.from_text('a=1&a=2') == QueryParamDict.from_text('a=2&a=1')
+        False
+        """
+        if not isinstance(other, QueryParamDict):
+            return super().__eq__(other)
+        if set(self.keys()) != set(other.keys()):
+            return False
+        for key in self.keys():
+            if self.getlist(key) != other.getlist(key):
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def to_text(self, full_quote=False):
         """
         Render and return a query string.

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -169,6 +169,45 @@ def test_not_equal():
     assert bono != u
 
 
+def test_url_query_param_order_independent_equality():
+    # Different key order should not affect URL equality (issue #280).
+    a = URL('http://example.com/foo?foo=bar&bar=foo')
+    b = URL('http://example.com/foo?bar=foo&foo=bar')
+    assert a == b
+
+
+def test_url_query_param_different_values_not_equal():
+    a = URL('http://example.com/?a=1&b=2')
+    b = URL('http://example.com/?a=2&b=1')
+    assert a != b
+
+
+def test_url_query_param_multi_value_order_matters():
+    # For repeated keys, value order within that key is preserved.
+    a = URL('http://example.com/?k=1&k=2')
+    b = URL('http://example.com/?k=2&k=1')
+    assert a != b
+
+
+def test_query_param_dict_order_independent_eq():
+    a = QueryParamDict.from_text('foo=bar&bar=foo')
+    b = QueryParamDict.from_text('bar=foo&foo=bar')
+    assert a == b
+
+
+def test_query_param_dict_multi_value_order_matters():
+    # Same-key value ordering is significant.
+    a = QueryParamDict.from_text('k=1&k=2')
+    b = QueryParamDict.from_text('k=2&k=1')
+    assert a != b
+
+
+def test_query_param_dict_different_values_not_equal():
+    a = QueryParamDict.from_text('a=1&b=2')
+    b = QueryParamDict.from_text('a=2&b=1')
+    assert a != b
+
+
 def _test_bad_utf8():  # not part of the API
     bad_bin_url = 'http://xn--9ca.com/%00%FF/%C3%A9'
     url = URL(bad_bin_url)


### PR DESCRIPTION
## Summary

`URL.__eq__` compares `query_params` using `OrderedMultiDict.__eq__`, which is insertion-order-sensitive. As a result, two URLs with identical query parameters in different order compare as unequal, even though RFC 3986 does not specify a canonical ordering for query parameters.

```python
a = URL('http://example.com/foo?foo=bar&bar=foo')
b = URL('http://example.com/foo?bar=foo&foo=bar')
a == b  # False  <-- was broken, now True
```

## Changes

- Add `QueryParamDict.__eq__` that compares by key set and per-key value lists, making key insertion order irrelevant while preserving the significance of value ordering within a repeated key (e.g. `k=1&k=2` vs `k=2&k=1` are still considered different).
- Add `QueryParamDict.__ne__` to match.
- Add six tests covering the new behaviour.

## Testing

```
pytest tests/test_urlutils.py  # 131 passed
```

Fixes #280