### PR TITLE
Fix IndexedSet slicing after removals and out-of-range negative indexing

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -158,6 +158,8 @@ class IndexedSet(MutableSet):
     def _get_real_index(self, index):
         if index < 0:
             index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError('IndexedSet index out of range')
         if not self.dead_indices:
             return index
         real_index = index
@@ -416,14 +418,8 @@ class IndexedSet(MutableSet):
         else:
             iter_slice = self.iter_slice(start, stop, step)
             return self.from_iterable(iter_slice)
-        if index < 0:
-            index += len(self)
         real_index = self._get_real_index(index)
-        try:
-            ret = self.item_list[real_index]
-        except IndexError:
-            raise IndexError('IndexedSet index out of range')
-        return ret
+        return self.item_list[real_index]
 
     def pop(self, index=None):
         "pop(index) -> remove the item at a given index (-1 by default)"

--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -392,10 +392,16 @@ class IndexedSet(MutableSet):
     def iter_slice(self, start, stop, step=None):
         "iterate over a slice of the set"
         iterable = self
-        if start is not None:
-            start = self._get_real_index(start)
-        if stop is not None:
-            stop = self._get_real_index(stop)
+        # start/stop are apparent (dead-slot-free) indices, the same space
+        # islice consumes; mapping them through _get_real_index() (item_list
+        # space) over-counted by the dead slots before each bound. Only
+        # negatives need normalizing, as islice rejects them.
+        # NB: a negative step slices the reversed stream with forward bounds
+        # (x[2:4:-1] == reversed(x)[2:4]), behavior since 2013.
+        if start is not None and start < 0:
+            start = max(len(self) + start, 0)
+        if stop is not None and stop < 0:
+            stop = max(len(self) + stop, 0)
         if step is not None and step < 0:
             step = -step
             iterable = reversed(self)

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -203,3 +203,37 @@ def test_iset_index_method():
         if i % 3:
             index = indexed_list.index(i)
             assert i == indexed_list.pop(index)
+
+
+def test_iset_slice_after_removal():
+    # PR #423: slice bounds were mapped into item_list space while islice
+    # consumed the apparent (dead-slot-free) stream, so any removal made
+    # slices over-count.
+    x = IndexedSet(range(10))
+    x.pop(2)  # leaves [0, 1, 3, 4, 5, 6, 7, 8, 9] with a dead slot
+    assert list(x[1:4]) == [1, 3, 4]
+    assert list(x[-3:]) == [7, 8, 9]
+    assert list(x[2:-1]) == [3, 4, 5, 6, 7, 8]
+    assert isinstance(x[1:4], IndexedSet)
+
+
+def test_iset_slice_agreement():
+    # Slicing must not depend on dead slots: a set with removals must slice
+    # identically to a freshly-built set with the same contents (all steps,
+    # including the reversed-window negative-step semantics), and positive
+    # steps must match list slicing exactly.
+    bounds = (None, -12, -9, -5, -1, 0, 1, 4, 8, 9, 12)
+    steps = (None, 1, 2, 3, -1, -2, -3)
+    for pops in ([], [2], [0, 1, 2], [7, 8, 9], [0, 3, 6, 9], [1, 2, 5, 6]):
+        iset = IndexedSet(range(10))
+        for p in pops:
+            iset.discard(p)
+        fresh = IndexedSet(iset)  # same contents, no dead slots
+        ref = list(iset)
+        for start in bounds:
+            for stop in bounds:
+                for step in steps:
+                    s = slice(start, stop, step)
+                    assert list(iset[s]) == list(fresh[s]), (pops, s)
+                    if step is None or step > 0:
+                        assert list(iset[s]) == ref[s], (pops, s)

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -237,3 +237,37 @@ def test_iset_slice_agreement():
                     assert list(iset[s]) == list(fresh[s]), (pops, s)
                     if step is None or step > 0:
                         assert list(iset[s]) == ref[s], (pops, s)
+
+
+def test_iset_scalar_index_bounds():
+    # Out-of-range negatives used to wrap silently: __getitem__ normalized
+    # the index and _get_real_index normalized it AGAIN, so x[-10] on a
+    # 9-element set returned x[-1], and pop(-15) removed a middle element.
+    x = IndexedSet(range(10))
+    x.pop(2)  # len 9, one dead slot
+    assert x[-1] == 9
+    assert x[-9] == 0
+    with raises(IndexError):
+        x[9]
+    with raises(IndexError):
+        x[-10]
+    with raises(IndexError):
+        x.pop(-15)
+    assert 4 in x  # pop(-15) formerly silently removed 4
+    with raises(IndexError):
+        IndexedSet()[0]
+
+
+def test_iset_scalar_index_multiple_dead_intervals():
+    # exercise the _get_real_index interval walk across several dead ranges
+    iset = IndexedSet(range(100))
+    for p in (5, 20, 40, 60, 80):
+        iset.discard(p)
+    assert len(iset.dead_indices) == 5  # below compaction threshold (100/8)
+    ref = list(iset)
+    for i in list(range(-95, 95, 7)) + [0, -1, 94, -95]:
+        assert iset[i] == ref[i]
+    with raises(IndexError):
+        iset[95]
+    with raises(IndexError):
+        iset[-96]


### PR DESCRIPTION
## Summary

Fixes two related bugs in `IndexedSet`:

1. **Slicing after removals returns wrong items** (#423): `iter_slice` mapped start/stop through `_get_real_index()` (item_list space) but then fed them to `islice` over `__iter__` (apparent/dead-slot-free space), so any prior removal caused slices to over-count by the number of dead slots before each bound.

2. **Out-of-range negative scalar indices wrap silently**: `__getitem__` normalized negative indices before passing them to `_get_real_index`, which normalized them *again*, so e.g. `x[-10]` on a 9-element set quietly returned `x[-1]` instead of raising `IndexError`, and `pop(-15)` silently removed the wrong element.

## Changes

### Commit 1: slicing fix (adopts #423's approach)
- **`iter_slice`**: Removed the two `_get_real_index()` calls. Bounds now stay in apparent index space (the space `islice` consumes). Only negatives need explicit normalization since `islice` rejects them. Negative-step reversed-window semantics (`x[2:4:-1] == reversed(x)[2:4]`, in place since 2013) are preserved.
- **Tests**: `test_iset_slice_after_removal` (direct repro from #423) + `test_iset_slice_agreement` (fuzz: 6 removal patterns × 11×11 bounds × 7 steps, verified against both a fresh-built `IndexedSet` and `list` slicing).

### Commit 2: scalar-index bounds check
- **`_get_real_index`**: Added bounds check after negative normalization → raises `IndexError` for out-of-range indices.
- **`__getitem__` scalar path**: Removed the redundant pre-normalization (the wraparound cause) and the now-dead `try/except` re-raise.
- **Tests**: `test_iset_scalar_index_bounds` + `test_iset_scalar_index_multiple_dead_intervals` (5 dead ranges, interval walk).

## Verification
- All 9 tests pass (`pytest tests/test_setutils.py`)
- Doctests pass (`pytest --doctest-modules boltons/setutils.py`)
- Existing reversed-window pin (line 21: `x[2:4:-1] == IndexedSet([8, 7])`) untouched and green

Co-authored-by: Andrew Chen <48723787+chuenchen309@users.noreply.github.com> (slicing fix adopted from #423)