### PR TITLE
tbutils anchor round-trip, funcutils keyword forwarding, pathutils tests

### DIFF
--- a/boltons/funcutils.py
+++ b/boltons/funcutils.py
@@ -35,7 +35,6 @@ correcting Python's standard metaprogramming facilities.
 """
 
 import sys
-import re
 import inspect
 import functools
 import itertools
@@ -743,6 +742,7 @@ class FunctionBuilder:
                  'body': lambda: 'pass',
                  'indent': lambda: 4,
                  "annotations": dict,
+                 'posonlyargs': list,
                  'filename': lambda: 'boltons.funcutils.FunctionBuilder'}
 
     _defaults.update(_argspec_defaults)
@@ -782,31 +782,31 @@ class FunctionBuilder:
                                      {},
                                      annotations)
 
-    _KWONLY_MARKER = re.compile(r"""
-    \*     # a star
-    \s*    # followed by any amount of whitespace
-    ,      # followed by a comma
-    \s*    # followed by any amount of whitespace
-    """, re.VERBOSE)
-
     def get_invocation_str(self):
-        kwonly_pairs = None
-        formatters = {}
-        if self.kwonlyargs:
-            kwonly_pairs = {arg: arg
-                                for arg in self.kwonlyargs}
-            formatters['formatvalue'] = lambda value: '=' + value
-
-        sig = inspect_formatargspec(self.args,
-                                    self.varargs,
-                                    self.varkw,
-                                    [],
-                                    kwonly_pairs,
-                                    kwonly_pairs,
-                                    {},
-                                    **formatters)
-        sig = self._KWONLY_MARKER.sub('', sig)
-        return sig[1:-1]
+        # Regular args with defaults (and keyword-only args) are forwarded
+        # as keywords (name=name), so values callers pass by keyword reach
+        # the wrapper's **kwargs instead of being silently flattened into
+        # *args (#343). Two classes must stay positional: positional-only
+        # params (keywords are rejected outright), and every regular arg
+        # when *varargs is present (a keyword-forwarded arg that precedes
+        # *varargs collides with non-empty varargs).
+        defaults = self.defaults or ()
+        args = list(self.args or ())
+        n_positional = len(args) - len(defaults)
+        parts, kw_parts = [], []
+        for i, arg in enumerate(args):
+            if (i >= n_positional and not self.varargs
+                    and arg not in self.posonlyargs):
+                kw_parts.append(arg + '=' + arg)
+            else:
+                parts.append(arg)
+        if self.varargs:
+            parts.append('*' + self.varargs)
+        parts += kw_parts
+        parts += [arg + '=' + arg for arg in self.kwonlyargs or ()]
+        if self.varkw:
+            parts.append('**' + self.varkw)
+        return ', '.join(parts)
 
     @classmethod
     def from_func(cls, func):
@@ -833,6 +833,15 @@ class FunctionBuilder:
                       'dict': getattr(func, '__dict__', {})}
 
         kwargs.update(cls._argspec_to_dict(func))
+
+        # getfullargspec merges positional-only params into args; recover
+        # them from the code object so they are never keyword-forwarded.
+        # (functools.partial objects have no __code__; posonly detection
+        # is skipped for them, preserving today's behavior.)
+        n_posonly = getattr(getattr(func, '__code__', None),
+                            'co_posonlyargcount', 0)
+        if n_posonly:
+            kwargs['posonlyargs'] = list(kwargs['args'][:n_posonly])
 
         if inspect.iscoroutinefunction(func):
             kwargs['is_async'] = True

--- a/boltons/tbutils.py
+++ b/boltons/tbutils.py
@@ -716,9 +716,10 @@ class ParsedException:
 
         .. note::
 
-           Note that this method does not output "anchors" (e.g.,
-           ``~~~~~^^``), as were added in Python 3.13. See the built-in
-           ``traceback`` module if these are necessary.
+           Anchor lines (e.g., ``~~~~~^^``, present in tracebacks from
+           Python 3.11+) round-trip: they are parsed into each frame's
+           ``source_line_anchor`` and re-emitted aligned beneath the
+           frame's source line.
         """
         lines = ['Traceback (most recent call last):']
 
@@ -729,6 +730,9 @@ class ParsedException:
             source_line = frame.get('source_line')
             if source_line:
                 lines.append(f'    {source_line}')
+                anchor = frame.get('source_line_anchor')
+                if anchor:
+                    lines.append(f'    {anchor}')
         if self.exc_msg:
             lines.append(f'{self.exc_type}: {self.exc_msg}')
         else:
@@ -802,7 +806,13 @@ class ParsedException:
                     line_no += 1
                     if (line_no + 1 < len(tb_lines)
                             and _underline_re.match(tb_lines[line_no + 1])):
-                        # To deal with anchors
+                        # store anchors dedented by the source line's
+                        # indentation so columns stay aligned with the
+                        # stripped source_line, whatever the tb's indent
+                        indent = len(next_line) - len(next_line.lstrip())
+                        anchor = tb_lines[line_no + 1][indent:].rstrip()
+                        if anchor:
+                            frame_dict['source_line_anchor'] = anchor
                         line_no += 1
             else:
                 break

--- a/tests/test_funcutils_fb.py
+++ b/tests/test_funcutils_fb.py
@@ -235,7 +235,7 @@ def test_wraps_expected():
     def expect_pair(func):
         @wraps(func, expected=[('c', 5)])
         def wrapped(*args, **kwargs):
-            args, c = args[:2], args[-1]
+            c = kwargs.pop('c')
             return func(*args, **kwargs) + (c,)
         return wrapped
 
@@ -244,7 +244,7 @@ def test_wraps_expected():
     def expect_dict(func):
         @wraps(func, expected={'c': 6})
         def wrapped(*args, **kwargs):
-            args, c = args[:2], args[-1]
+            c = kwargs.pop('c')
             return func(*args, **kwargs) + (c,)
         return wrapped
 
@@ -277,7 +277,7 @@ def test_get_arg_names():
     [
         (["a", "b"], None, None, None, "a, b", "(a, b)"),
         (None, "args", "kwargs", None, "*args, **kwargs", "(*args, **kwargs)"),
-        ("a", None, None, dict(a="a"), "a", "(a)"),
+        ("a", None, None, dict(a="a"), "a=a", "(a)"),
     ],
 )
 def test_get_invocation_sig_str(

--- a/tests/test_funcutils_fb_py3.py
+++ b/tests/test_funcutils_fb_py3.py
@@ -1,4 +1,5 @@
 import time
+import sys
 import inspect
 import functools
 from collections import defaultdict
@@ -127,30 +128,6 @@ def test_get_arg_names():
     assert fb_example.get_arg_names(only_required=True) == ('req',)
 
 
-@pytest.mark.parametrize('signature,should_match',
-                         [('a, *, b', True),
-                          ('a,*,b', True),
-                          ('a, * , b', True),
-                          ('a, *,\nb', True),
-                          ('a, *\n,b', True),
-                          ('a, b', False),
-                          ('a, *args', False),
-                          ('a, *args, **kwargs', False),
-                          ('*args', False),
-                          ('*args, **kwargs', False)])
-def test_FunctionBuilder_KWONLY_MARKER(signature, should_match):
-    """
-    _KWONLY_MARKER matches the keyword-only argument separator,
-    regardless of whitespace.
-
-    Note: it assumes the signature is valid Python.
-    """
-    matched = bool(FunctionBuilder._KWONLY_MARKER.search(signature))
-    message = "{!r}: should_match was {}, but result was {}".format(
-        signature, should_match, matched)
-    assert bool(matched) == should_match, message
-
-
 def test_FunctionBuilder_add_arg_kwonly():
     fb = FunctionBuilder('return_val', doc='returns the value',
                          body='return val')
@@ -217,22 +194,10 @@ def test_get_invocation_sig_str(
 def test_wraps_inner_kwarg_only():
     """from https://github.com/mahmoud/boltons/issues/261
 
-    mh responds to the issue:
-
-    You'll notice that when kw-only args are involved the first time
-    (wraps(f)(g)) it works fine. The other way around, however,
-    wraps(g)(f) fails, because by the very nature of funcutils.wraps,
-    you're trying to give f the same signature as g. And f's signature
-    is not like g's. g supports positional b and f() does not.
-
-    If you want to make a wrapper which converts a keyword-only
-    argument to one that can be positional or keyword only, that'll
-    require a different approach for now.
-
-    A potential fix would be to pass all function arguments as
-    keywords. But doubt that's the right direction, because, while I
-    have yet to add positional argument only support, that'll
-    definitely throw a wrench into things.
+    wraps(g)(f) used to raise a TypeError when f's b was keyword-only,
+    because g's defaulted b was forwarded positionally. Defaulted args
+    are now forwarded as keywords (with positional-only awareness), so
+    the wrapper works in both directions.
     """
     from boltons.funcutils import wraps
 
@@ -247,9 +212,7 @@ def test_wraps_inner_kwarg_only():
     assert g(3) == 30
     assert wraps(f)(g)(3) == 3  # yay, g got the f default (not so with functools.wraps!)
 
-    # but this doesn't work
-    with pytest.raises(TypeError):
-        wraps(g)(f)(3)
+    assert wraps(g)(f)(3) == 30  # g's b=10 is forwarded as a keyword
 
     return
 
@@ -316,3 +279,53 @@ def test_wraps_hide_wrapped():
     new_new_sig = inspect.signature(new_new_func, follow_wrapped=True)
 
     assert len(new_new_sig.parameters) == 0
+
+
+def test_wraps_defaulted_arg_keyword_forwarding():
+    # issue #343: a defaulted arg passed by keyword must reach the
+    # wrapper's **kwargs, not be flattened into *args
+    def flip(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*reversed(args), **kwargs)
+        return wrapper
+
+    def power(x, y, msg=''):
+        return (x, y, msg)
+
+    assert flip(power)(3, 2, msg='abc') == (2, 3, 'abc')
+    assert flip(power)(3, 2) == (2, 3, '')
+
+
+def test_wraps_defaulted_arg_before_varargs():
+    # a defaulted arg preceding *varargs must stay positional; forwarding
+    # it as a keyword would raise "got multiple values for argument"
+    def deco(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapper
+
+    def func(x, y=1, *rest):
+        return (x, y, rest)
+
+    assert deco(func)(1, 2, 3) == (1, 2, (3,))
+    assert deco(func)(1) == (1, 1, ())
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8),
+                    reason='positional-only params require 3.8+')
+def test_wraps_posonly_defaulted_arg():
+    # positional-only params, defaulted or not, are never keyword-forwarded
+    ns = {}
+    exec('def func(x, y=2, /, z=3):\n    return (x, y, z)', ns)
+    func = ns['func']
+
+    def deco(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapper
+
+    assert deco(func)(1, 5) == (1, 5, 3)
+    assert deco(func)(1, 5, z=7) == (1, 5, 7)

--- a/tests/test_pathutils.py
+++ b/tests/test_pathutils.py
@@ -1,0 +1,41 @@
+from os.path import expanduser, join, normpath
+
+from boltons.pathutils import augpath, shrinkuser, expandpath
+
+
+def test_augpath():
+    assert augpath('foo.bar') == 'foo.bar'
+    assert augpath('foo.bar', dpath='/tmp') == join('/tmp', 'foo.bar')
+    assert augpath(join('a', 'b', 'foo.bar'), base='qux') == join('a', 'b', 'qux.bar')
+    assert augpath('foo.bar', prefix='p_', base='bar', suffix='_s', ext='.baz') == 'p_bar_s.baz'
+    assert augpath('foo', ext='.txt') == 'foo.txt'
+    assert augpath('foo.bar', ext='') == 'foo'
+
+
+def test_augpath_multidot():
+    assert augpath('foo.tar.gz', suffix='_new', multidot=True) == 'foo_new.tar.gz'
+    assert augpath('foo.tar.gz', suffix='_new', multidot=False) == 'foo.tar_new.gz'
+    assert augpath('foo.tar.gz', ext='.zip', multidot=True) == 'foo.zip'
+    assert augpath('foo.tar.gz', ext='.zip', multidot=False) == 'foo.tar.zip'
+
+
+def test_shrinkuser():
+    home = expanduser('~')
+    assert shrinkuser(home) == '~'
+    assert shrinkuser(home + '/projects') == join('~', 'projects')
+    # a sibling path that merely starts with the home string is not shrunk
+    assert shrinkuser(home + 'extra') == normpath(home + 'extra')
+    assert shrinkuser(home + '/a//b/../c') == join('~', 'a', 'c')
+    assert shrinkuser(home + '/projects', home='$HOME') == join('$HOME', 'projects')
+    assert shrinkuser(home, home='$HOME') == '$HOME'
+    assert shrinkuser('/etc/passwd') == normpath('/etc/passwd')
+
+
+def test_expandpath(monkeypatch):
+    assert expandpath('~') == expanduser('~')
+    monkeypatch.setenv('BOLTONS_TEST_VAR', 'eggs')
+    assert expandpath('$BOLTONS_TEST_VAR') == 'eggs'
+    assert expandpath('~/$BOLTONS_TEST_VAR') == expanduser('~/eggs')
+    monkeypatch.delenv('BOLTONS_UNDEFINED_VAR', raising=False)
+    assert expandpath('$BOLTONS_UNDEFINED_VAR') == '$BOLTONS_UNDEFINED_VAR'
+    assert expandpath('foo') == 'foo'

--- a/tests/test_tbutils_parsed_exc.py
+++ b/tests/test_tbutils_parsed_exc.py
@@ -51,9 +51,7 @@ RuntimeError"""
                                    'funcname': 'load'}
     assert parsed_tb.to_string() == _tb_str
 
-def test_parsed_exc_with_anchor():
-    """parse a traceback with anchor lines beneath source lines"""
-    _tb_str = """\
+_ANCHOR_TB_STR = """\
 Traceback (most recent call last):
   File "main.py", line 3, in <module>
     print(add(1, "two"))
@@ -63,23 +61,34 @@ Traceback (most recent call last):
            ~~^~~
 TypeError: unsupported operand type(s) for +: 'int' and 'str'"""
 
-    parsed_tb = ParsedException.from_string(_tb_str)
+
+def test_parsed_exc_with_anchor():
+    """parse a traceback with anchor lines beneath source lines"""
+    parsed_tb = ParsedException.from_string(_ANCHOR_TB_STR)
 
     assert parsed_tb.exc_type == 'TypeError'
     assert parsed_tb.exc_msg == "unsupported operand type(s) for +: 'int' and 'str'"
     assert parsed_tb.frames == [{'source_line': 'print(add(1, "two"))',
-                                  'filepath': 'main.py',
-                                  'lineno': '3',
-                                  'funcname': '<module>'},
-                                  {'source_line': 'return a + b',
-                                  'filepath': 'add.py',
-                                  'lineno': '2',
-                                  'funcname': 'add'}]
-    
-    # Note: not checking the anchor lines (indices 3, 6) because column details not currently stored in ParsedException
-    _tb_str_lines = _tb_str.splitlines()
-    _tb_str_without_anchor = "\n".join(_tb_str_lines[:3] + _tb_str_lines[4:6] + _tb_str_lines[7:])
-    assert parsed_tb.to_string() == _tb_str_without_anchor
+                                 'source_line_anchor': '      ^^^^^^^^^^^^^',
+                                 'filepath': 'main.py',
+                                 'lineno': '3',
+                                 'funcname': '<module>'},
+                                {'source_line': 'return a + b',
+                                 'source_line_anchor': '       ~~^~~',
+                                 'filepath': 'add.py',
+                                 'lineno': '2',
+                                 'funcname': 'add'}]
+    assert parsed_tb.to_string() == _ANCHOR_TB_STR
+
+
+def test_parsed_exc_with_anchor_indented():
+    """anchors stay aligned when the whole traceback arrives indented,
+    e.g. pasted from a log: source_line is stripped, and the anchor is
+    dedented by the same amount"""
+    plain = ParsedException.from_string(_ANCHOR_TB_STR)
+    indented = ParsedException.from_string(
+        '\n'.join('    ' + line for line in _ANCHOR_TB_STR.splitlines()))
+    assert indented.frames == plain.frames
 
 
 def test_parsed_exc_truncated():


### PR DESCRIPTION
Three independent commits picking up where the recent drive-by PRs left off:

* **tbutils**: `ParsedException` now round-trips anchor lines (`~~~~^^`, present in tracebacks from Python 3.11+). They parse into each frame's `source_line_anchor`, dedented by the source line's own indentation, and `to_string()` re-emits them aligned beneath the source line. Fixes #333.
* **funcutils**: wrappers built by `wraps` now receive defaulted (non-positional-only, non-pre-varargs) and keyword-only args in `**kwargs` instead of having them flattened into `*args`, so `flip(power)(3, 2, msg='abc')` returns `(2, 3, 'abc')` instead of `('abc', 2, 3)`. Positional-only params (recovered via `co_posonlyargcount`) and args preceding `*varargs` stay positional. Also lifts the #261 limitation. Fixes #343.
* **pathutils**: first test coverage for `augpath`, `shrinkuser`, and `expandpath`.

Supersedes #411, #412, #414.

* #411 stored `source_line = next_line[4:]`, a hardcoded 4-space dedent, which regresses `from_string`'s existing tolerance for indented tracebacks (e.g. one pasted from a log with a uniform extra indent keeps leading whitespace or loses characters in `source_line`).
* #412's `get_invocation_str` rewrite broke positional-only params: `def f(x, y=2, /)` wrapped and called as `f(1, 5)` raises `TypeError: got some positional-only arguments passed as keyword arguments`. It also broke defaulted args before varargs: `def f(x, y=1, *va)` called as `f(1, 2, 3)` raises `TypeError: got multiple values for argument 'y'`. Both work on master and keep working here.
* #414 covered the same pathutils behaviors across 272 lines of Arrange/Act/Assert ceremony; this version asserts the same facts in about 45 lines.
