### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Validate version
@@ -29,7 +29,7 @@ jobs:
           fi
       - name: Build package
         run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -43,17 +43,17 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1, pinned 2026-07-16
 
   verify:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Wait for PyPI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,9 +30,9 @@ jobs:
           - { name: "3.7", python: "3.7", os: ubuntu-22.04, tox: py37 }
           - { name: "PyPy3", python: "pypy-3.9", os: ubuntu-latest, tox: pypy3 }
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true


### PR DESCRIPTION
Hi! Following up my earlier contribution (#414) with a small supply-chain hardening PR.

This pins all `uses:` refs in `tests.yaml` and `publish.yml` to full commit SHAs — **same versions as today** (v4/v5 majors unchanged), just made immutable. Tags are mutable refs: if an action's repo is compromised, the attacker can re-point `v4` and every consumer silently runs attacker code on the next CI run — this is exactly what happened in the 2024 `tj-actions/changed-files` incident. A 40-character commit SHA can't be re-pointed. Each pin keeps a `# vX.Y.Z` comment, which Dependabot/Renovate read so the pins can be bumped automatically.

Ran OpenSSF Scorecard on the repo: the `Pinned-Dependencies` check currently scores 0/10; with this change it rises to 7/10.

Two judgment calls to flag:

1. `pypa/gh-action-pypi-publish@release/v1` is a deliberately moving branch that pypa auto-updates. I pinned it to the current head (with the pin date in the comment) since it runs at the most sensitive moment of the pipeline (publish), but if you prefer pypa's auto-updating behavior I'm happy to drop that one line from this PR.

2. The remaining Scorecard warning (`pipCommand not pinned`, `publish.yml`) is the post-publish smoke test that installs the just-published boltons back from PyPI — hash-pinning that line isn't meaningful since the artifact's identity is the thing under test, so I've left it untouched.

Happy to adjust anything. If useful, I can follow up separately with a `dependabot.yml` so the pins stay fresh without manual work.