### PR TITLE
Fix ZeroDivisionError in backoff/backoff_iter with factor=1.0 and no count

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -648,8 +648,14 @@ def backoff_iter(start, stop, count=None, factor=2.0, jitter=False):
         raise ValueError('expected stop >= start, not %r' % stop)
     if count is None:
         denom = start if start else 1
-        count = 1 + math.ceil(math.log(stop/denom, factor))
-        count = count if start else count + 1
+        if factor == 1.0:
+            if start != stop:
+                raise ValueError('expected factor > 1.0 when count is None'
+                                 ' and start != stop, not %r' % factor)
+            count = 1
+        else:
+            count = 1 + math.ceil(math.log(stop/denom, factor))
+            count = count if start else count + 1
     if count != 'repeat' and count < 0:
         raise ValueError('count must be positive or "repeat", not %r' % count)
     if jitter:

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -489,6 +489,21 @@ def test_backoff_validation():
         backoff(2, 8, jitter=20)
 
 
+def test_backoff_constant_factor():
+    from boltons.iterutils import backoff
+
+    # factor=1.0 (constant backoff) is allowed with an explicit count
+    assert backoff(1, 10, count=5, factor=1.0) == [1.0, 1.0, 1.0, 1.0, 1.0]
+    assert backoff(2, 10, count=3, factor=1.0) == [2.0, 2.0, 2.0]
+    # start == stop needs no growth, so an inferred count yields a single value
+    assert backoff(5, 5, factor=1.0) == [5.0]
+    # inferring the count from a non-growing factor is impossible, not a crash
+    with pytest.raises(ValueError):
+        backoff(1, 10, factor=1.0)
+    with pytest.raises(ValueError):
+        backoff(0, 10, factor=1.0)
+
+
 def test_backoff_jitter():
     from boltons.iterutils import backoff
 


### PR DESCRIPTION
backoff_iter treats factor >= 1.0 as valid (it raises only for factor < 1.0), and factor=1.0 works fine with an explicit count or count='repeat'. But when count is None the count is inferred with math.ceil(math.log(stop/denom, factor)), and math.log(x, 1.0) divides by zero, so backoff(1, 10, factor=1.0) raises ZeroDivisionError. backoff(5, 5, factor=1.0) hits the same crash even though backoff(5, 5) returns [5.0].

The count-inference branch now special-cases factor=1.0: it yields a single value when start == stop, and raises a clear ValueError otherwise (a non-growing factor cannot reach a larger stop, so the count is genuinely uninferable). Explicit-count, 'repeat', factor > 1.0, and start=0 paths are unchanged.

Repro:

    from boltons.iterutils import backoff
    backoff(1, 10, factor=1.0)   # ZeroDivisionError before, clear ValueError now
    backoff(5, 5, factor=1.0)    # ZeroDivisionError before, [5.0] now