### PR TITLE
Fix Table.to_text crashes on None headers and empty first-row tables

### DIFF
--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -290,7 +290,7 @@ class Table:
         if self.headers:
             self._width = len(self.headers)
             return
-        self._width = max([len(d) for d in self._data])
+        self._width = max((len(d) for d in self._data), default=0)  # empty islice after [[]]
 
     def _fill(self):
         width, filler = self._width, [None]
@@ -566,15 +566,17 @@ class Table:
         lines = []
         widths = []
         headers = list(self.headers)
+        if with_headers and self._width > len(headers):  # match to_html None padding
+            headers.extend([None] * (self._width - len(headers)))
         text_data = [[to_text(cell, maxlen=maxlen) for cell in row]
                      for row in self._data]
         for idx in range(self._width):
             cur_widths = [len(row[idx]) for row in text_data]
             if with_headers:
                 cur_widths.append(len(to_text(headers[idx], maxlen=maxlen)))
-            widths.append(max(cur_widths))
+            widths.append(max(cur_widths) if cur_widths else 0)
         if with_headers:
-            lines.append(' | '.join([h.center(widths[i])
+            lines.append(' | '.join([to_text(h, maxlen=maxlen).center(widths[i])
                                      for i, h in enumerate(headers)]))
             lines.append('-|-'.join(['-' * w for w in widths]))
         for row in text_data:

--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -290,7 +290,7 @@ class Table:
         if self.headers:
             self._width = len(self.headers)
             return
-        self._width = max((len(d) for d in self._data), default=0)  # empty islice after [[]]
+        self._width = max((len(d) for d in self._data), default=0)
 
     def _fill(self):
         width, filler = self._width, [None]
@@ -566,7 +566,7 @@ class Table:
         lines = []
         widths = []
         headers = list(self.headers)
-        if with_headers and self._width > len(headers):  # match to_html None padding
+        if with_headers and self._width > len(headers):
             headers.extend([None] * (self._width - len(headers)))
         text_data = [[to_text(cell, maxlen=maxlen) for cell in row]
                      for row in self._data]

--- a/tests/test_tableutils.py
+++ b/tests/test_tableutils.py
@@ -52,3 +52,28 @@ def test_table_obj():
     t4 = Table.from_object(TestType())
     assert len(t4) == 1
     assert 'greeting' in t4.headers
+
+
+def test_table_empty_first_row_only_does_not_crash():
+    # First row used as headers; remaining data is an empty islice (truthy).
+    t = Table([[]])
+    assert t.headers == []
+    assert list(t) == []
+    assert t.to_text() == "\n"  # same as Table([])
+
+
+def test_table_to_text_none_and_non_str_headers():
+    t = Table([["a", "b"]], headers=[None, 1])
+    text = t.to_text()
+    assert "None" in text
+    assert "1" in text
+    assert "a" in text and "b" in text
+
+
+def test_table_to_text_pads_short_headers():
+    # Empty first row as headers, then a data row of width 1.
+    t = Table([[], [1]])
+    assert t._width == 1
+    text = t.to_text()
+    assert "1" in text
+    assert "None" in text

--- a/tests/test_tableutils.py
+++ b/tests/test_tableutils.py
@@ -55,11 +55,10 @@ def test_table_obj():
 
 
 def test_table_empty_first_row_only_does_not_crash():
-    # First row used as headers; remaining data is an empty islice (truthy).
     t = Table([[]])
     assert t.headers == []
     assert list(t) == []
-    assert t.to_text() == "\n"  # same as Table([])
+    assert t.to_text() == Table([]).to_text()
 
 
 def test_table_to_text_none_and_non_str_headers():
@@ -71,9 +70,7 @@ def test_table_to_text_none_and_non_str_headers():
 
 
 def test_table_to_text_pads_short_headers():
-    # Empty first row as headers, then a data row of width 1.
     t = Table([[], [1]])
-    assert t._width == 1
     text = t.to_text()
     assert "1" in text
     assert "None" in text


### PR DESCRIPTION
Table([[]]) makes max() fail on an empty width, and to_text crashes when headers contain None or are shorter than the table width. Use max(..., default=0), pad headers like to_html, and stringify header cells.