### PR TITLE
fix: scale isoformat fractional seconds in isoparse

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -122,7 +122,6 @@ def isoparse(iso_str):
     # Fractional seconds from isoformat are 1-6 digits of a second, not raw microseconds.
     if len(dt_args) >= 7:
         dt_args[6] = int((parts[6] + '000000')[:6])
-        dt_args = dt_args[:7]
     return datetime(*dt_args)
 
 

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -117,7 +117,7 @@ def isoparse(iso_str):
     .. _dateutil: https://pypi.python.org/pypi/python-dateutil
 
     """
-    parts = [p for p in _NONDIGIT_RE.split(iso_str) if p]
+    parts = _NONDIGIT_RE.split(iso_str)
     dt_args = [int(p) for p in parts]
     # Fractional seconds from isoformat are 1-6 digits of a second, not raw microseconds.
     if len(dt_args) >= 7:

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -117,7 +117,12 @@ def isoparse(iso_str):
     .. _dateutil: https://pypi.python.org/pypi/python-dateutil
 
     """
-    dt_args = [int(p) for p in _NONDIGIT_RE.split(iso_str)]
+    parts = [p for p in _NONDIGIT_RE.split(iso_str) if p]
+    dt_args = [int(p) for p in parts]
+    # Fractional seconds from isoformat are 1-6 digits of a second, not raw microseconds.
+    if len(dt_args) >= 7:
+        dt_args[6] = int((parts[6] + '000000')[:6])
+        dt_args = dt_args[:7]
     return datetime(*dt_args)
 
 

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -119,7 +119,7 @@ def isoparse(iso_str):
     """
     parts = _NONDIGIT_RE.split(iso_str)
     dt_args = [int(p) for p in parts]
-    # Fractional seconds from isoformat are 1-6 digits of a second, not raw microseconds.
+    # isoformat fractional digits are a second fraction, not raw microseconds.
     if len(dt_args) >= 7:
         dt_args[6] = int((parts[6] + '000000')[:6])
     return datetime(*dt_args)

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,8 +1,8 @@
-from datetime import timedelta, date
+from datetime import datetime, timedelta, date
 
 import pytest
 
-from boltons.timeutils import daterange
+from boltons.timeutils import daterange, isoparse
 
 
 def test_daterange_years():
@@ -56,3 +56,13 @@ def test_daterange_with_same_start_stop():
     assert next(date_range_inclusive) == today
     with pytest.raises(StopIteration):
         next(date_range_inclusive)
+
+
+def test_isoparse_fractional_seconds_match_isoformat():
+    # isoformat(timespec='milliseconds') yields 3 fractional digits; treat as a second fraction.
+    ms = datetime(2026, 7, 18, 5, 8, 2, 851000)
+    assert isoparse(ms.isoformat(timespec='milliseconds')) == ms
+    assert isoparse('2020-01-01T00:00:00.851') == datetime(2020, 1, 1, 0, 0, 0, 851000)
+    us = datetime(2020, 1, 1, 0, 0, 0, 123456)
+    assert isoparse(us.isoformat(timespec='microseconds')) == us
+    assert isoparse('2020-01-01T00:00:00') == datetime(2020, 1, 1, 0, 0, 0)

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -59,7 +59,6 @@ def test_daterange_with_same_start_stop():
 
 
 def test_isoparse_fractional_seconds_match_isoformat():
-    # isoformat(timespec='milliseconds') yields 3 fractional digits; treat as a second fraction.
     ms = datetime(2026, 7, 18, 5, 8, 2, 851000)
     assert isoparse(ms.isoformat(timespec='milliseconds')) == ms
     assert isoparse('2020-01-01T00:00:00.851') == datetime(2020, 1, 1, 0, 0, 0, 851000)


### PR DESCRIPTION
boltons.timeutils.isoparse hits wrong-microsecond when isoformat timespec=milliseconds .851 as 851us not 851000us. This PR fixes the regression with a focused test covering the case.
