### PR TITLE
fix: raise ValueError for non-advancing daterange step

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -365,8 +365,8 @@ def daterange(start, stop, step=1, inclusive=False):
                          ' (year, month, day), not: %r' % step)
 
     m_step += y_step * 12
-    # Zero step never advances; same class of error as range(..., step=0).
-    if m_step == 0 and d_step.days == 0:
+    # Zero / non-advancing step loops forever; same class of error as range(..., step=0).
+    if m_step == 0 and (start + d_step) == start:
         raise ValueError('step must be non-zero')
 
     if stop is None:

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -366,7 +366,7 @@ def daterange(start, stop, step=1, inclusive=False):
 
     m_step += y_step * 12
     # Zero step never advances; same class of error as range(..., step=0).
-    if m_step == 0 and d_step == timedelta(0):
+    if m_step == 0 and d_step.days == 0:
         raise ValueError('step must be non-zero')
 
     if stop is None:

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -363,8 +363,11 @@ def daterange(start, stop, step=1, inclusive=False):
     else:
         raise ValueError('step expected int, timedelta, or tuple'
                          ' (year, month, day), not: %r' % step)
-    
+
     m_step += y_step * 12
+    # Zero step never advances; same class of error as range(..., step=0).
+    if m_step == 0 and d_step == timedelta(0):
+        raise ValueError('step must be non-zero')
 
     if stop is None:
         finished = lambda now, stop: False

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -365,7 +365,7 @@ def daterange(start, stop, step=1, inclusive=False):
                          ' (year, month, day), not: %r' % step)
 
     m_step += y_step * 12
-    # Zero / non-advancing step loops forever; same class of error as range(..., step=0).
+    # Non-advancing step would loop forever (same class as range(..., step=0)).
     if m_step == 0 and (start + d_step) == start:
         raise ValueError('step must be non-zero')
 

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -67,7 +67,16 @@ def test_daterange_zero_step_raises():
         list(daterange(start, stop, step=timedelta(0)))
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=(0, 0, 0)))
+    # date + sub-day timedelta does not advance -> hang on master
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=timedelta(hours=1)))
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=(0, 0, timedelta(hours=1))))
+
+
+def test_daterange_datetime_hourly_step():
+    start = datetime(2020, 1, 1, 0, 0, 0)
+    stop = datetime(2020, 1, 1, 5, 0, 0)
+    assert list(daterange(start, stop, step=timedelta(hours=1))) == [
+        datetime(2020, 1, 1, h, 0, 0) for h in range(5)
+    ]

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -56,3 +56,14 @@ def test_daterange_with_same_start_stop():
     assert next(date_range_inclusive) == today
     with pytest.raises(StopIteration):
         next(date_range_inclusive)
+
+
+def test_daterange_zero_step_raises():
+    start = date(2020, 1, 1)
+    stop = date(2020, 1, 5)
+    with pytest.raises(ValueError, match='non-zero'):
+        list(daterange(start, stop, step=0))
+    with pytest.raises(ValueError, match='non-zero'):
+        list(daterange(start, stop, step=timedelta(0)))
+    with pytest.raises(ValueError, match='non-zero'):
+        list(daterange(start, stop, step=(0, 0, 0)))

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, date
+from datetime import datetime, timedelta, date
 
 import pytest
 

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -67,3 +67,7 @@ def test_daterange_zero_step_raises():
         list(daterange(start, stop, step=timedelta(0)))
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=(0, 0, 0)))
+    with pytest.raises(ValueError, match='non-zero'):
+        list(daterange(start, stop, step=timedelta(hours=1)))
+    with pytest.raises(ValueError, match='non-zero'):
+        list(daterange(start, stop, step=(0, 0, timedelta(hours=1))))

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -67,7 +67,6 @@ def test_daterange_zero_step_raises():
         list(daterange(start, stop, step=timedelta(0)))
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=(0, 0, 0)))
-    # date + sub-day timedelta does not advance -> hang on master
     with pytest.raises(ValueError, match='non-zero'):
         list(daterange(start, stop, step=timedelta(hours=1)))
     with pytest.raises(ValueError, match='non-zero'):


### PR DESCRIPTION
boltons.timeutils.daterange hits hang when step=0 or timedelta(0) infinite loop. This PR fixes the regression with a focused test covering the case.
