### PR TITLE
fix: treat empty MultiReplace maps as no-op

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1214,10 +1214,14 @@ class MultiReplace:
             regex_values.append(f'(?P<{group_name}>{exp})')
             self.group_map[group_name] = vals[1]
 
-        self.combined_pattern = re.compile(
-            '|'.join(regex_values),
-            flags=options['flags']
-        )
+        # Empty sub_map must be a no-op; '|'.join([]) compiles to '' and matches everywhere.
+        if not regex_values:
+            self.combined_pattern = None
+        else:
+            self.combined_pattern = re.compile(
+                '|'.join(regex_values),
+                flags=options['flags']
+            )
 
     def _get_value(self, match):
         """Given a match object find replacement value."""
@@ -1230,6 +1234,8 @@ class MultiReplace:
         Given an input string, run all substitutions given in the
         constructor.
         """
+        if self.combined_pattern is None:
+            return text
         return self.combined_pattern.sub(self._get_value, text)
 
 

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1214,7 +1214,7 @@ class MultiReplace:
             regex_values.append(f'(?P<{group_name}>{exp})')
             self.group_map[group_name] = vals[1]
 
-        # Empty sub_map must be a no-op; '|'.join([]) compiles to '' and matches everywhere.
+        # '|'.join([]) compiles to '' and matches everywhere; empty map is a no-op.
         if not regex_values:
             self.combined_pattern = None
         else:

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -141,6 +141,13 @@ class TestMultiReplace(TestCase):
         m = strutils.MultiReplace({'cat.+': 'kedi', r'purple': 'mor', })
         self.assertEqual(m.sub('The cat.+ is purple'), 'The kedi is mor')
 
+    def test_empty_sub_map_is_noop(self):
+        """Empty substitution maps leave text unchanged (no KeyError)."""
+        self.assertEqual(strutils.MultiReplace({}).sub('hello world'), 'hello world')
+        self.assertEqual(strutils.multi_replace('hello world', {}), 'hello world')
+        self.assertEqual(strutils.MultiReplace([]).sub('hello world'), 'hello world')
+        self.assertEqual(strutils.multi_replace('hello world', []), 'hello world')
+
 
 def test_human_readable_list():
     """Test the human_readable_list function with various inputs."""

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -142,7 +142,6 @@ class TestMultiReplace(TestCase):
         self.assertEqual(m.sub('The cat.+ is purple'), 'The kedi is mor')
 
     def test_empty_sub_map_is_noop(self):
-        """Empty substitution maps leave text unchanged (no KeyError)."""
         self.assertEqual(strutils.MultiReplace({}).sub('hello world'), 'hello world')
         self.assertEqual(strutils.multi_replace('hello world', {}), 'hello world')
         self.assertEqual(strutils.MultiReplace([]).sub('hello world'), 'hello world')


### PR DESCRIPTION
boltons.strutils.MultiReplace/multi_replace hits KeyError when empty sub_map compiles empty regex then match.lastgroup is None. This PR fixes the regression with a focused test covering the case.
