### PR TITLE
Classify Pearson types IV/V/VI instead of raising 'missed a spot'

### DIFF
--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -448,6 +448,12 @@ class Stats:
             k = c1 ** 2 / (4 * c0 * c2)
             if k < 0:
                 return 1  # Beta
+            elif round(k, precision) == 1:
+                return 5  # Type V
+            elif k < 1:
+                return 4  # Type IV
+            else:
+                return 6  # Type VI
         raise RuntimeError('missed a spot')
     pearson_type = _StatsProperty('pearson_type', _calc_pearson_type)
 

--- a/tests/test_statsutils.py
+++ b/tests/test_statsutils.py
@@ -11,6 +11,15 @@ def test_stats_basic():
     assert da.median == 9.5
 
 
+def test_pearson_type_covers_kappa_ge_zero():
+    # pearson_type used to raise RuntimeError('missed a spot') whenever the
+    # Pearson criterion (kappa) was >= 0, i.e. Types IV/V/VI, which ordinary
+    # small samples routinely land in. It should classify them instead.
+    assert Stats([8, 4, 4, 4, 5, 1, 6, 5]).pearson_type == 4  # Type IV
+    for data in ([0, 1, 2, 3, 4], [1, 1, 2, 3, 5, 8, 13], range(9)):
+        assert Stats(data).pearson_type in (0, 1, 2, 3, 4, 5, 6, 7)
+
+
 def _test_pearson():
     import random
     from statsutils import pearson_type


### PR DESCRIPTION
## The bug

`Stats.pearson_type` crashes on ordinary data:

```python
>>> from boltons.statsutils import Stats
>>> Stats([8, 4, 4, 4, 5, 1, 6, 5]).pearson_type
Traceback (most recent call last):
  ...
RuntimeError: missed a spot
```

The final branch only classifies the Pearson criterion `kappa < 0` (Type I) and then falls through to `raise RuntimeError('missed a spot')` for `kappa >= 0`. Small samples land in `kappa >= 0` routinely — a quick sweep of random small datasets hits the `RuntimeError` on roughly 1-2% of them (including near-normal data). The existing `_test_pearson` helper never triggered it because it only exercises distributions that fall into the already-handled Types 0/1/2/3.

## Fix

Fill in the standard `kappa` classification for the remaining cases, using the same `round(x, precision)` boundary test that the surrounding Normal and Gamma branches already use:

- `0 < kappa < 1` → Type IV
- `kappa == 1` → Type V
- `kappa > 1` → Type VI

The `kappa < 0` (Type I) case is unchanged.

## Verification

- `Stats([8, 4, 4, 4, 5, 1, 6, 5]).pearson_type` now returns `4` (Type IV) instead of raising. A sweep that previously produced `RuntimeError` on ~1-2% of random small samples now returns a valid type (0–7) for every one.
- Added a regression test (`test_pearson_type_covers_kappa_ge_zero`) that fails on `master` with `RuntimeError: missed a spot` and passes with this change.
- Full suite: **438 passed**. `test_stats_basic` (which pins mean/variance/skewness/kurtosis/median) is unchanged.

---

*Disclosure:* this PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the crash, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
