### PR TITLE
Fix JSONLIterator hang when rel_seek finds no newline

### DIFF
--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -181,8 +181,7 @@ class JSONLIterator:
         while '\n' not in cur:
             cur = fo.read(bsize)
             if not cur:
-                # EOF before a newline: no further complete lines.
-                return
+                return  # EOF before a newline
             total_read += bsize
         newline_offset = cur.index('\n') + total_read - bsize
         fo.seek(cur_pos + newline_offset)

--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -180,11 +180,11 @@ class JSONLIterator:
         cur_pos = fo.tell()
         while '\n' not in cur:
             cur = fo.read(bsize)
+            if not cur:
+                # EOF before a newline: no further complete lines.
+                return
             total_read += bsize
-        try:
-            newline_offset = cur.index('\n') + total_read - bsize
-        except ValueError:
-            raise  # TODO: seek to end?
+        newline_offset = cur.index('\n') + total_read - bsize
         fo.seek(cur_pos + newline_offset)
 
     def _init_rel_seek(self):

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from boltons.jsonutils import (JSONLIterator,
@@ -37,3 +38,24 @@ def test_jsonl_iterator():
     jsonl_iter = JSONLIterator(open(JSONL_DATA_PATH), reverse=True)
     jsonl_list = list(jsonl_iter)
     assert jsonl_list == ref
+
+
+
+def test_jsonl_rel_seek_eof_without_newline():
+    """rel_seek with no following newline must stop at EOF, not spin."""
+    class CountingStringIO(io.StringIO):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, **kw)
+            self.read_calls = 0
+
+        def read(self, size=-1):
+            self.read_calls += 1
+            if self.read_calls > 64:
+                raise AssertionError('too many reads; _align_to_newline hung')
+            return super().read(size)
+
+    bio = CountingStringIO('{"a": 1}')
+    assert list(JSONLIterator(bio, rel_seek=0.5)) == []
+
+    bio = CountingStringIO('')
+    assert list(JSONLIterator(bio, rel_seek=0.5)) == []

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -42,7 +42,6 @@ def test_jsonl_iterator():
 
 
 def test_jsonl_rel_seek_eof_without_newline():
-    """rel_seek with no following newline must stop at EOF, not spin."""
     class CountingStringIO(io.StringIO):
         def __init__(self, *a, **kw):
             super().__init__(*a, **kw)


### PR DESCRIPTION
## Summary

`JSONLIterator` with a relative seek could hang forever when aligning to a newline on a file that has no newline at/after the seek point.

Stop at EOF instead of looping.

## Test plan

- `pytest` covering align-at-EOF with no newline