### PR TITLE
Fix xfrange empty/hang on negative step

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -527,7 +527,6 @@ def xfrange(stop, start=None, step=1.0):
         # swap when all args are used
         stop, start = start * 1.0, stop * 1.0
     cur = start
-    # Match range()/frange: negative step walks downward (was always `cur < stop`).
     if step > 0:
         while cur < stop:
             yield cur

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -527,9 +527,15 @@ def xfrange(stop, start=None, step=1.0):
         # swap when all args are used
         stop, start = start * 1.0, stop * 1.0
     cur = start
-    while cur < stop:
-        yield cur
-        cur += step
+    # Match range()/frange: negative step walks downward (was always `cur < stop`).
+    if step > 0:
+        while cur < stop:
+            yield cur
+            cur += step
+    else:
+        while cur > stop:
+            yield cur
+            cur += step
 
 
 def frange(stop, start=None, step=1.0):
@@ -546,21 +552,7 @@ def frange(stop, start=None, step=1.0):
     >>> frange(5, 0, step=-1.25)
     [5.0, 3.75, 2.5, 1.25]
     """
-    if not step:
-        raise ValueError('step must be non-zero')
-    if start is None:
-        start, stop = 0.0, stop * 1.0
-    else:
-        # swap when all args are used
-        stop, start = start * 1.0, stop * 1.0
-    count = int(math.ceil((stop - start) / step))
-    ret = [None] * count
-    if not ret:
-        return ret
-    ret[0] = start
-    for i in range(1, count):
-        ret[i] = ret[i - 1] + step
-    return ret
+    return list(xfrange(stop, start, step))
 
 
 def backoff(start, stop, count=None, factor=2.0, jitter=False):

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -658,3 +658,17 @@ def test_partition_multiple():
     assert positive == [2, 3]
     assert negative == [-1, -2]
     assert zero == [0]
+
+
+def test_xfrange_negative_step():
+    from boltons.iterutils import frange, xfrange
+
+    # Same cases as frange's doctest / range()-style negative steps.
+    assert list(xfrange(5, 0, step=-1.25)) == [5.0, 3.75, 2.5, 1.25]
+    assert list(xfrange(5, 0, step=-1)) == [5.0, 4.0, 3.0, 2.0, 1.0]
+    assert list(xfrange(2, -2, step=-0.5)) == [
+        2.0, 1.5, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5]
+    # Empty when the step points away from stop (must not hang).
+    assert list(xfrange(0, 5, step=-1)) == []
+    assert frange(5, 0, step=-1.25) == list(xfrange(5, 0, step=-1.25))
+    assert frange(5) == list(xfrange(5))

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -663,12 +663,10 @@ def test_partition_multiple():
 def test_xfrange_negative_step():
     from boltons.iterutils import frange, xfrange
 
-    # Same cases as frange's doctest / range()-style negative steps.
     assert list(xfrange(5, 0, step=-1.25)) == [5.0, 3.75, 2.5, 1.25]
     assert list(xfrange(5, 0, step=-1)) == [5.0, 4.0, 3.0, 2.0, 1.0]
     assert list(xfrange(2, -2, step=-0.5)) == [
         2.0, 1.5, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5]
-    # Empty when the step points away from stop (must not hang).
     assert list(xfrange(0, 5, step=-1)) == []
     assert frange(5, 0, step=-1.25) == list(xfrange(5, 0, step=-1.25))
     assert frange(5) == list(xfrange(5))


### PR DESCRIPTION
## Summary

`xfrange` always compared with `cur < stop`, so negative steps returned empty or hung depending on the bounds.

Match `frange` / range-style step direction.

## Test plan

- `pytest` for negative-step cases