### PR TITLE
Fix off-by-one in Bits length check

### DIFF
--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -161,7 +161,7 @@ class Bits:
             raise ValueError('Bits cannot represent negative values')
         if len_ is None:
             len_ = len(f'{val:b}')
-        if val > 2 ** len_:
+        if val >= 2 ** len_:
             raise ValueError(f'value {val} cannot be represented with {len_} bits')
         self.val = val  # data is stored internally as integer
         self.len = len_

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -110,3 +110,15 @@ def test_bits():
             ).as_int()
         ),
         Bits('101'))
+
+
+def test_bits_len_bound():
+    # The largest value representable in n bits is 2 ** n - 1, so 2 ** n must
+    # be rejected rather than silently producing an over-long Bits.
+    # Largest value that fits is accepted and round-trips.
+    assert Bits(3, 2).as_bin() == '11'
+    # 2 ** len_ does not fit in len_ bits and must raise.
+    with raises(ValueError):
+        Bits(4, 2)
+    with raises(ValueError):
+        Bits(1, 0)


### PR DESCRIPTION
### Summary

`Bits.__init__` guards against a value too large for the requested bit length with `val > 2 ** len_`. The largest value representable in `len_` bits is `2 ** len_ - 1`, so the check is off by one: `2 ** len_` is wrongly accepted.

```python
>>> from boltons.mathutils import Bits
>>> b = Bits(4, 2)          # 4 needs 3 bits, but len_=2 is accepted
>>> b.as_bin()
'100'                        # 3 chars, though b.len == 2
>>> Bits(b.as_bin()).len     # doesn't round-trip
3
```

The over-long value silently violates the `len` / `__len__` / `__getitem__` invariant.

### Fix

Change `>` to `>=` so a value needing more than `len_` bits raises, exactly as the guard's own error message ("cannot be represented with N bits") promises. This mirrors the correct `>=` boundary already used in `__getitem__`.

The auto-computed branch (`len_ = len(f'{val:b}')` when `len_` is omitted) is unaffected: there `val < 2 ** len_` always holds, so the stricter comparison never fires. Only explicit-length overflows like `Bits(4, 2)` / `Bits(1, 0)` are newly (correctly) rejected; `Bits(3, 2)` — the true maximum — still works.

### Tests

Added `test_bits_len_bound`. Full suite passes locally (`pytest`, 446 passed).
