### PR TITLE
Fix US timezone fold handling

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -490,16 +490,16 @@ def _first_sunday_on_or_after(dt):
 # In the US, since 2007, DST starts at 2am (standard time) on the second
 # Sunday in March, which is the first Sunday on or after Mar 8.
 DSTSTART_2007 = datetime(1, 3, 8, 2)
-# and ends at 2am (DST time; 1am standard time) on the first Sunday of Nov.
-DSTEND_2007 = datetime(1, 11, 1, 1)
+# and ends at 2am (standard time) on the first Sunday of Nov.
+DSTEND_2007 = datetime(1, 11, 1, 2)
 # From 1987 to 2006, DST used to start at 2am (standard time) on the first
-# Sunday in April and to end at 2am (DST time; 1am standard time) on the last
+# Sunday in April and to end at 2am (standard time) on the last
 # Sunday of October, which is the first Sunday on or after Oct 25.
 DSTSTART_1987_2006 = datetime(1, 4, 1, 2)
-DSTEND_1987_2006 = datetime(1, 10, 25, 1)
+DSTEND_1987_2006 = datetime(1, 10, 25, 2)
 # From 1967 to 1986, DST used to start at 2am (standard time) on the last
-# Sunday in April (the one on or after April 24) and to end at 2am (DST time;
-# 1am standard time) on the last Sunday of October, which is the first Sunday
+# Sunday in April (the one on or after April 24) and to end at 2am (standard
+# time) on the last Sunday of October, which is the first Sunday
 # on or after Oct 25.
 DSTSTART_1967_1986 = datetime(1, 4, 24, 2)
 DSTEND_1967_1986 = DSTEND_1987_2006
@@ -529,6 +529,18 @@ class USTimeZone(tzinfo):
     def utcoffset(self, dt):
         return self.stdoffset + self.dst(dt)
 
+    def _dst_range(self, year):
+        if year > 2006:
+            dststart, dstend = DSTSTART_2007, DSTEND_2007
+        elif 1986 < year < 2007:
+            dststart, dstend = DSTSTART_1987_2006, DSTEND_1987_2006
+        elif 1966 < year < 1987:
+            dststart, dstend = DSTSTART_1967_1986, DSTEND_1967_1986
+        else:
+            return None, None
+        return (_first_sunday_on_or_after(dststart.replace(year=year)),
+                _first_sunday_on_or_after(dstend.replace(year=year)))
+
     def dst(self, dt):
         if dt is None or dt.tzinfo is None:
             # An exception may be sensible here, in one or both cases.
@@ -540,24 +552,41 @@ class USTimeZone(tzinfo):
 
         # Find start and end times for US DST. For years before 1967, return
         # ZERO for no DST.
-        if 2006 < dt.year:
-            dststart, dstend = DSTSTART_2007, DSTEND_2007
-        elif 1986 < dt.year < 2007:
-            dststart, dstend = DSTSTART_1987_2006, DSTEND_1987_2006
-        elif 1966 < dt.year < 1987:
-            dststart, dstend = DSTSTART_1967_1986, DSTEND_1967_1986
-        else:
+        start, end = self._dst_range(dt.year)
+        if start is None:
             return ZERO
-
-        start = _first_sunday_on_or_after(dststart.replace(year=dt.year))
-        end = _first_sunday_on_or_after(dstend.replace(year=dt.year))
 
         # Can't compare naive to aware objects, so strip the timezone
         # from dt first.
-        if start <= dt.replace(tzinfo=None) < end:
+        dt = dt.replace(tzinfo=None)
+        if start + HOUR <= dt < end - HOUR:
             return HOUR
-        else:
-            return ZERO
+        if end - HOUR <= dt < end:
+            return ZERO if getattr(dt, 'fold', 0) else HOUR
+        if start <= dt < start + HOUR:
+            return HOUR if getattr(dt, 'fold', 0) else ZERO
+        return ZERO
+
+    def fromutc(self, dt):
+        if dt.tzinfo is not self:
+            raise ValueError('fromutc: dt.tzinfo is not self')
+
+        start, end = self._dst_range(dt.year)
+        if start is None:
+            return dt + self.stdoffset
+
+        start = start.replace(tzinfo=self)
+        end = end.replace(tzinfo=self)
+        std_time = dt + self.stdoffset
+        dst_time = std_time + HOUR
+
+        if end <= dst_time < end + HOUR:
+            return std_time.replace(fold=1)
+        if std_time < start or dst_time >= end:
+            return std_time
+        if start <= std_time < end - HOUR:
+            return dst_time
+        return std_time
 
 
 Eastern = USTimeZone(-5, "Eastern",  "EST", "EDT")

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,8 +1,8 @@
-from datetime import timedelta, date
+from datetime import timedelta, date, datetime, timezone
 
 import pytest
 
-from boltons.timeutils import daterange
+from boltons.timeutils import daterange, Eastern
 
 
 def test_daterange_years():
@@ -56,3 +56,25 @@ def test_daterange_with_same_start_stop():
     assert next(date_range_inclusive) == today
     with pytest.raises(StopIteration):
         next(date_range_inclusive)
+
+
+def test_us_timezone_dst_fold():
+    unfolded = datetime(2011, 11, 6, 1, 30, tzinfo=Eastern, fold=0)
+    folded = datetime(2011, 11, 6, 1, 30, tzinfo=Eastern, fold=1)
+
+    assert unfolded.utcoffset() == -4 * timedelta(hours=1)
+    assert unfolded.tzname() == 'EDT'
+    assert folded.utcoffset() == -5 * timedelta(hours=1)
+    assert folded.tzname() == 'EST'
+
+
+def test_us_timezone_fromutc_sets_fold():
+    first = datetime(2011, 11, 6, 5, 30, tzinfo=timezone.utc).astimezone(Eastern)
+    second = datetime(2011, 11, 6, 6, 30, tzinfo=timezone.utc).astimezone(Eastern)
+
+    assert first.replace(tzinfo=None) == datetime(2011, 11, 6, 1, 30)
+    assert first.fold == 0
+    assert first.tzname() == 'EDT'
+    assert second.replace(tzinfo=None) == datetime(2011, 11, 6, 1, 30)
+    assert second.fold == 1
+    assert second.tzname() == 'EST'


### PR DESCRIPTION
Addresses the `USTimeZone` half of #141.

## Reproduction

On current `master`, ambiguous US/Eastern wall times at the 2011 fall DST transition ignore `datetime.fold`:

```python
from datetime import datetime
from boltons.timeutils import Eastern

unfolded = datetime(2011, 11, 6, 1, 30, tzinfo=Eastern, fold=0)
folded = datetime(2011, 11, 6, 1, 30, tzinfo=Eastern, fold=1)
print(unfolded.utcoffset(), unfolded.tzname())  # -05:00 EST, should be -04:00 EDT
print(folded.utcoffset(), folded.tzname())      # -05:00 EST
```

Converting from UTC has the same problem: both `2011-11-06T05:30Z` and `2011-11-06T06:30Z` map to a local `01:30` with `fold=0`, so the two distinct instants become indistinguishable.

## Root cause

`USTimeZone.dst()` used a single `[start, end)` DST interval and stored the DST end transition as 1am standard time, so the repeated fall-back hour was always treated as standard time. `USTimeZone` also relied on the base `tzinfo.fromutc()`, which cannot mark repeated local times with `fold=1`.

## Fix

- Correct the US DST transition end constants to 2am standard time (matching the transition rule the comments already describe).
- Factor transition-range selection into `USTimeZone._dst_range()`.
- Make `dst()` fold-aware for both the repeated hour (fall back) and the missing hour (spring forward), following PEP 495 semantics.
- Implement `USTimeZone.fromutc()` so that the second occurrence of a repeated local time is returned with `fold=1`.

Dependency-free, no new imports, and compatible with the Python versions boltons supports (`fold` is read via `getattr(dt, 'fold', 0)`).

### Scope note

This PR deliberately covers only `USTimeZone`. The issue also mentions `LocalTZInfo`, whose `is_dst()` delegates to `time.mktime()`/`time.localtime()`; making that fold-aware requires gap/ambiguity detection against the host's own zone rules and cannot be regression-tested portably (`time.tzset` is unavailable on Windows, and the class caches `time.timezone`/`time.altzone` at import). I did not want to ship an untested change to it in the same PR — happy to follow up separately if you'd like that half too, or to adjust the scope of this one.

## Validation

- `python -m pytest tests\test_timeutils.py -q` → 6 passed
- Reverting only `boltons\timeutils.py` while keeping the new regression tests → 2 failed, 4 passed (the tests genuinely fail without the fix)
- `python -m pytest` → 447 passed in 7.21s
- No configured lint command was found in `pyproject.toml`, `setup.cfg`, or `tox.ini`.
