### PR TITLE
Support negative step in xfrange to match frange

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -516,6 +516,8 @@ def xfrange(stop, start=None, step=1.0):
 
     >>> tuple(xfrange(1, 3, step=0.75))
     (1.0, 1.75, 2.5)
+    >>> tuple(xfrange(5, 0, step=-1.25))
+    (5.0, 3.75, 2.5, 1.25)
 
     See :func:`frange` for more details.
     """
@@ -527,7 +529,7 @@ def xfrange(stop, start=None, step=1.0):
         # swap when all args are used
         stop, start = start * 1.0, stop * 1.0
     cur = start
-    while cur < stop:
+    while (cur < stop) if step > 0 else (cur > stop):
         yield cur
         cur += step
 


### PR DESCRIPTION
## Summary

`xfrange` is documented as *"Same as `frange`, but generator-based"* and shares `frange`'s exact argument handling (including the `range()`-style start/stop swap). But its loop hard-codes the ascending condition:

```python
cur = start
while cur < stop:
    yield cur
    cur += step
```

so a **negative step** yields nothing. `frange` supports a negative step — its docstring pins it:

```python
>>> frange(5, 0, step=-1.25)
[5.0, 3.75, 2.5, 1.25]
```

whereas the equivalent `xfrange` call returned an empty generator:

```python
>>> tuple(xfrange(5, 0, step=-1.25))
()          # before this fix; should equal frange's output
```

## Fix

Choose the loop condition based on the sign of `step`:

```diff
-    while cur < stop:
+    while (cur < stop) if step > 0 else (cur > stop):
```

## Tests

Added a negative-step doctest to `xfrange` mirroring `frange`'s:

```python
>>> tuple(xfrange(5, 0, step=-1.25))
(5.0, 3.75, 2.5, 1.25)
```

The existing positive-step doctest (`xfrange(1, 3, step=0.75)`) is unchanged and still passes. I verified `xfrange` now matches `frange` across all of `frange`'s documented cases (ascending, empty, and the negative-step case).
