### PR TITLE
Edge-case hardening sweep: six long-standing crash/hang/correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ for an average of one 33-commit release about every 9 weeks. Versions
 are named according to the [CalVer](https://calver.org) versioning
 scheme (`YY.MINOR.MICRO`).
 
+## 26.1.1
+
+_(unreleased)_
+
+- Fixed [`tableutils.Table.to_text`][tableutils.Table] crashes on empty tables, `None` headers, and short header rows; empty headers now render no header row, matching `to_html`
+- Fixed [`timeutils.isoparse`][timeutils.isoparse] misreading fractional seconds (`.851` parsed as 851µs instead of 851000µs); >6-digit fractions now truncate instead of raising
+- Fixed [`timeutils.daterange`][timeutils.daterange] looping forever on non-advancing steps: zero and self-cancelling month/day steps now raise `ValueError`, wrong-direction steps yield nothing like `range()`
+- Fixed [`strutils.MultiReplace`][strutils.MultiReplace] raising `KeyError` on empty substitution maps (now a no-op)
+- Fixed [`jsonutils.JSONLIterator`][jsonutils.JSONLIterator] hanging when a seek lands past the last newline, and negative `rel_seek` values seeking past EOF (sign bug)
+- Fixed [`iterutils.xfrange`][iterutils.xfrange] yielding nothing for descending ranges; now shares [`frange`][iterutils.frange]'s count-based semantics, so both agree at inexact float boundaries
+
 ## 26.1.0
 
 _(July 17, 2026)_

--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -526,8 +526,9 @@ def xfrange(stop, start=None, step=1.0):
     else:
         # swap when all args are used
         stop, start = start * 1.0, stop * 1.0
+    count = int(math.ceil((stop - start) / step))
     cur = start
-    while cur < stop:
+    for _ in range(count):
         yield cur
         cur += step
 

--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -156,7 +156,7 @@ class JSONLIterator:
             raise ValueError("'rel_seek' expected a float between"
                              " -1.0 and 1.0, not %r" % rel_seek)
         elif rel_seek < 0:
-            rel_seek = 1.0 - rel_seek
+            rel_seek = 1.0 + rel_seek
         self._rel_seek = rel_seek
         self._blocksize = 4096
         if rel_seek is not None:
@@ -180,11 +180,13 @@ class JSONLIterator:
         cur_pos = fo.tell()
         while '\n' not in cur:
             cur = fo.read(bsize)
+            if not cur:
+                # no newline until EOF; a partial trailing line was
+                # never yieldable from a mid-line seek anyway
+                fo.seek(0, os.SEEK_END)
+                return
             total_read += bsize
-        try:
-            newline_offset = cur.index('\n') + total_read - bsize
-        except ValueError:
-            raise  # TODO: seek to end?
+        newline_offset = cur.index('\n') + total_read - bsize
         fo.seek(cur_pos + newline_offset)
 
     def _init_rel_seek(self):

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -1230,6 +1230,8 @@ class MultiReplace:
         Given an input string, run all substitutions given in the
         constructor.
         """
+        if not self.group_map:
+            return text
         return self.combined_pattern.sub(self._get_value, text)
 
 

--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -290,7 +290,7 @@ class Table:
         if self.headers:
             self._width = len(self.headers)
             return
-        self._width = max([len(d) for d in self._data])
+        self._width = max([len(d) for d in self._data], default=0)
 
     def _fill(self):
         width, filler = self._width, [None]
@@ -566,16 +566,21 @@ class Table:
         lines = []
         widths = []
         headers = list(self.headers)
+        if with_headers and headers:
+            headers.extend([None] * (self._width - len(headers)))
+        else:
+            headers = []
+        text_headers = [to_text(h, maxlen=maxlen) for h in headers]
         text_data = [[to_text(cell, maxlen=maxlen) for cell in row]
                      for row in self._data]
         for idx in range(self._width):
             cur_widths = [len(row[idx]) for row in text_data]
-            if with_headers:
-                cur_widths.append(len(to_text(headers[idx], maxlen=maxlen)))
-            widths.append(max(cur_widths))
-        if with_headers:
+            if text_headers:
+                cur_widths.append(len(text_headers[idx]))
+            widths.append(max(cur_widths, default=0))
+        if text_headers:
             lines.append(' | '.join([h.center(widths[i])
-                                     for i, h in enumerate(headers)]))
+                                     for i, h in enumerate(text_headers)]))
             lines.append('-|-'.join(['-' * w for w in widths]))
         for row in text_data:
             lines.append(' | '.join([cell.center(widths[j])

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -116,8 +116,17 @@ def isoparse(iso_str):
     .. _iso8601: https://pypi.python.org/pypi/iso8601
     .. _dateutil: https://pypi.python.org/pypi/python-dateutil
 
+    >>> isoparse('1970-01-01T00:00:00.851')
+    datetime.datetime(1970, 1, 1, 0, 0, 0, 851000)
+
     """
-    dt_args = [int(p) for p in _NONDIGIT_RE.split(iso_str)]
+    parts = _NONDIGIT_RE.split(iso_str)
+    dt_args = [int(p) for p in parts]
+    if len(parts) > 6:
+        # fractional-second digits are not microseconds until scaled:
+        # '.851' means 851000us, not 851us. Digits past microsecond
+        # precision are truncated (e.g. nanosecond timestamps).
+        dt_args[6] = int(parts[6].ljust(6, '0')[:6])
     return datetime(*dt_args)
 
 

--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -324,7 +324,10 @@ def daterange(start, stop, step=1, inclusive=False):
             *stop*. Can be an :class:`int` number of days, a
             :class:`datetime.timedelta`, or a :class:`tuple` of integers,
             `(year, month, day)`. Positive and negative *step* values
-            are supported.
+            are supported. A step that does not advance (e.g. ``0`` or a
+            self-cancelling tuple like ``(0, 1, -31)``) raises
+            :exc:`ValueError`; a step pointed away from *stop* yields
+            nothing, like ``range(1, 5, -1)``.
         inclusive (bool): Whether or not the *stop* date can be
             returned. *stop* is only returned when a *step* falls evenly
             on it.
@@ -375,6 +378,13 @@ def daterange(start, stop, step=1, inclusive=False):
     
     m_step += y_step * 12
 
+    def _advance(cur):
+        if m_step:
+            m_y_step, cur_month = divmod((cur.month - 1) + m_step, 12)
+            cur = cur.replace(year=cur.year + m_y_step,
+                              month=(cur_month + 1))
+        return cur + d_step
+
     if stop is None:
         finished = lambda now, stop: False
     elif start <= stop:
@@ -383,13 +393,28 @@ def daterange(start, stop, step=1, inclusive=False):
         finished = operator.lt if inclusive else operator.le
     now = start
 
+    # guard against steps that cannot make progress: a stationary step
+    # (e.g. 0, or month/day cancellation like (0, 1, -31)) would loop
+    # forever, and a step pointed away from *stop* would walk off
+    # unboundedly. The former raises, the latter yields nothing, like
+    # range(1, 5, -1).
+    probe = _advance(start)
+    if probe == start:
+        raise ValueError('step does not advance: %r' % (step,))
+    if stop is not None and start != stop and (probe > start) != (stop > start):
+        return
+
     while not finished(now, stop):
         yield now
-        if m_step:
-            m_y_step, cur_month = divmod((now.month - 1) + m_step, 12)
-            now = now.replace(year=now.year + m_y_step,
-                              month=(cur_month + 1))
-        now = now + d_step
+        prev, now = now, _advance(now)
+        if now == prev:
+            raise ValueError('step does not advance: %r' % (step,))
+        if stop is not None and abs(stop - now) >= abs(stop - prev):
+            # the step has stopped approaching stop (e.g. month/day
+            # cancellation partway through a sequence); terminate
+            # rather than iterate forever. finished() above yields the
+            # same result for plain overshoot.
+            return
     return
 
 

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -658,3 +658,42 @@ def test_partition_multiple():
     assert positive == [2, 3]
     assert negative == [-1, -2]
     assert zero == [0]
+
+
+# Tests for frange/xfrange
+
+def test_xfrange_descending():
+    from boltons.iterutils import xfrange
+
+    assert list(xfrange(5, 0, step=-1.25)) == [5.0, 3.75, 2.5, 1.25]
+
+
+def test_xfrange_wrong_direction():
+    from boltons.iterutils import xfrange
+
+    assert list(xfrange(1, 5, step=-1)) == []
+    assert list(xfrange(5, 0)) == []
+
+
+def test_frange_inexact_boundary_counts():
+    from boltons.iterutils import frange
+
+    assert len(frange(1.0, step=0.1)) == 10
+    assert len(frange(10.0, step=0.1)) == 100
+
+
+def test_xfrange_matches_frange():
+    from boltons.iterutils import frange, xfrange
+
+    assert list(xfrange(1.0, step=0.1)) == frange(1.0, step=0.1)
+    assert list(xfrange(10.0, step=0.1)) == frange(10.0, step=0.1)
+    assert list(xfrange(1, 3, step=0.75)) == frange(1, 3, step=0.75)
+
+
+def test_frange_xfrange_zero_step():
+    from boltons.iterutils import frange, xfrange
+
+    with pytest.raises(ValueError):
+        frange(10, step=0)
+    with pytest.raises(ValueError):
+        list(xfrange(10, step=0))

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -37,3 +37,47 @@ def test_jsonl_iterator():
     jsonl_iter = JSONLIterator(open(JSONL_DATA_PATH), reverse=True)
     jsonl_list = list(jsonl_iter)
     assert jsonl_list == ref
+
+
+class _CappedReadFile:
+    """Wraps a file object, raising if read() is called more than
+    max_reads times, so a non-terminating read loop fails fast
+    instead of hanging the test suite."""
+    def __init__(self, fo, max_reads=100):
+        self._fo = fo
+        self._reads = 0
+        self._max_reads = max_reads
+
+    def read(self, size=-1):
+        self._reads += 1
+        if self._reads > self._max_reads:
+            raise RuntimeError('read() called more than %s times,'
+                               ' likely an infinite loop' % self._max_reads)
+        return self._fo.read(size)
+
+    def __iter__(self):
+        return iter(self._fo)
+
+    def __getattr__(self, name):
+        return getattr(self._fo, name)
+
+
+def test_jsonl_iterator_mid_last_line_seek_terminates(tmp_path):
+    # a rel_seek landing mid-final-line of a file with no trailing
+    # newline used to loop forever in _align_to_newline
+    path = tmp_path / 'no_trailing_newline.jsonl'
+    path.write_text('{"1": 1}\n{"2": 2}')
+    fo = _CappedReadFile(open(str(path)))
+    jsonl_iter = JSONLIterator(fo, rel_seek=0.9)
+    assert list(jsonl_iter) == []
+
+
+def test_jsonl_iterator_rel_seek_negative():
+    # negative rel_seek used to normalize to >1.0, seeking past EOF
+    # and looping forever in _align_to_newline
+    ref = list(JSONLIterator(open(JSONL_DATA_PATH)))
+    fo = _CappedReadFile(open(JSONL_DATA_PATH))
+    tail = list(JSONLIterator(fo, rel_seek=-0.5))
+    assert tail
+    assert tail == list(JSONLIterator(open(JSONL_DATA_PATH), rel_seek=0.5))
+    assert tail == ref[len(ref) - len(tail):]

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -314,3 +314,12 @@ def test_pluralize_x():
     assert pluralize('FOX') == 'FOXES'
     # Irregular '-x' words are unaffected (handled before the rule).
     assert pluralize('ox') == 'oxen'
+
+
+
+def test_multi_replace_empty_mapping():
+    # An empty substitution map is a no-op; previously the empty combined
+    # pattern matched everywhere with lastgroup None, raising KeyError.
+    assert strutils.MultiReplace({}).sub('foo bar') == 'foo bar'
+    assert strutils.MultiReplace([]).sub('foo bar') == 'foo bar'
+    assert strutils.multi_replace('foo bar', {}) == 'foo bar'

--- a/tests/test_tableutils.py
+++ b/tests/test_tableutils.py
@@ -52,3 +52,36 @@ def test_table_obj():
     t4 = Table.from_object(TestType())
     assert len(t4) == 1
     assert 'greeting' in t4.headers
+
+
+
+def test_to_text_empty_table():
+    # used to raise ValueError from max() over an empty sequence
+    assert Table([[]]).to_text() == ''
+
+
+def test_to_text_none_headers():
+    # used to raise AttributeError calling .center() on a None header
+    t = Table([[None, 'b'], [1, 2]])
+    lines = t.to_text().splitlines()
+    header_cells = [c.strip() for c in lines[0].split(' | ')]
+    # None headers render the same as None data cells
+    assert header_cells[0] == 'None'
+
+
+def test_to_text_no_headers():
+    # used to raise IndexError; empty headers mean no header row or
+    # separator rule, same as to_html
+    t = Table([[], [1]])
+    assert t.headers == []
+    assert t.to_text() == '1'
+
+
+def test_to_text_short_headers_padded():
+    # used to raise IndexError; non-empty headers shorter than the
+    # table width get padded with None cells, same as to_html
+    t = Table([[1, 2]], headers=[])
+    t.headers = ['a']
+    lines = t.to_text().splitlines()
+    header_cells = [c.strip() for c in lines[0].split(' | ')]
+    assert header_cells == ['a', 'None']

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,8 +1,8 @@
-from datetime import timedelta, date
+from datetime import timedelta, date, datetime
 
 import pytest
 
-from boltons.timeutils import daterange
+from boltons.timeutils import daterange, isoparse
 
 
 def test_daterange_years():
@@ -56,3 +56,27 @@ def test_daterange_with_same_start_stop():
     assert next(date_range_inclusive) == today
     with pytest.raises(StopIteration):
         next(date_range_inclusive)
+
+
+
+def test_isoparse_basic():
+    dt = datetime(2020, 1, 2, 3, 4, 5)
+    assert isoparse(dt.isoformat()) == dt
+
+
+def test_isoparse_fractional_seconds():
+    # isoformat() round-trip at every timespec, not just microseconds
+    dt = datetime(2020, 1, 2, 3, 4, 5, 851000)
+    assert isoparse(dt.isoformat(timespec='milliseconds')) == dt
+    assert isoparse(dt.isoformat(timespec='microseconds')) == dt
+    assert isoparse(dt.isoformat()) == dt
+
+    # leading zeros in the fraction scale correctly
+    assert isoparse('2020-01-02T03:04:05.051').microsecond == 51000
+    assert isoparse('2020-01-02T03:04:05.000001').microsecond == 1
+
+
+def test_isoparse_fraction_overprecise():
+    # digits past microsecond precision (e.g. nanosecond timestamps)
+    # truncate rather than raise
+    assert isoparse('2020-01-01T00:00:00.123456789').microsecond == 123456

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -80,3 +80,39 @@ def test_isoparse_fraction_overprecise():
     # digits past microsecond precision (e.g. nanosecond timestamps)
     # truncate rather than raise
     assert isoparse('2020-01-01T00:00:00.123456789').microsecond == 123456
+
+
+def test_daterange_step_does_not_advance():
+    start, stop = date(2020, 1, 1), date(2020, 3, 1)
+
+    with pytest.raises(ValueError):
+        list(daterange(start, stop, step=0))
+
+    with pytest.raises(ValueError):
+        list(daterange(start, stop, step=(0, 0, 0)))
+
+    # month/day cancellation: +1 month, -31 days is stationary from Jan 1
+    with pytest.raises(ValueError):
+        list(daterange(start, stop, step=(0, 1, -31)))
+
+    # non-advancing steps raise even for infinite ranges
+    with pytest.raises(ValueError):
+        list(daterange(start, None, step=0))
+
+
+def test_daterange_wrong_direction():
+    # a step pointed away from stop yields nothing, like range(1, 5, -1)
+    assert list(daterange(date(2020, 1, 1), date(2020, 1, 5), step=-1)) == []
+    assert list(daterange(date(2020, 1, 5), date(2020, 1, 1), step=1)) == []
+    assert list(daterange(date(2020, 1, 1), date(2020, 3, 1),
+                          step=(0, -1, 0))) == []
+
+
+def test_daterange_datetime_hourly():
+    # daterange accepts datetimes (datetime subclasses date) with
+    # sub-day timedelta steps
+    start = datetime(2020, 1, 1, 0)
+    stop = datetime(2020, 1, 1, 12)
+    hours = list(daterange(start, stop, step=timedelta(hours=3)))
+    assert hours == [datetime(2020, 1, 1, 0), datetime(2020, 1, 1, 3),
+                     datetime(2020, 1, 1, 6), datetime(2020, 1, 1, 9)]


### PR DESCRIPTION
A review pass over boltons' iteration, parsing, and rendering edge cases turned up six long-standing bugs: two non-termination hangs, three crashes, and one silent data corruption. One commit per fix, each with regression tests that fail on the pre-fix code.

- **tableutils**: `Table.to_text()` crashed three ways on degenerate input (`Table([[]])`, `None` headers, short header rows). Header rendering now mirrors `to_html`'s conventions, including no header row for empty headers.
- **timeutils/isoparse**: fractional seconds were parsed as literal integers, so `.851` became 851µs instead of 851000µs, silently corrupting the `isoformat()` round-trip the docstring promises. Over-precise fractions (>6 digits) now deliberately truncate.
- **timeutils/daterange**: any step that couldn't make progress toward `stop` looped forever: zero steps, self-cancelling month/day tuples like `(0, 1, -31)`, and wrong-direction steps. Replaced with a progress invariant: stationary steps raise `ValueError`, wrong-direction yields nothing like `range(1, 5, -1)`.
- **strutils**: `MultiReplace({})` raised `KeyError: None` on any input (empty pattern matches everywhere with no lastgroup). Now a no-op.
- **jsonutils**: `JSONLIterator` read in an infinite loop when a seek landed past the last newline; also fixes the `rel_seek` negative-normalization sign bug (`1.0 - rel_seek` mapped −0.3 to 1.3, past EOF). Resolves the old `TODO: seek to end?`.
- **iterutils**: `xfrange` assumed ascending iteration (descending ranges yielded nothing) and disagreed with `frange` on element counts at inexact float boundaries. Both now share `frange`'s deterministic count-based semantics; `frange`'s output is unchanged.

Full suite: 463 passed.

Supersedes #430, #431, #432, #433, #435, and #436, which were closed by their author and went stale; the fixes here were re-derived and generalized from an independent review of each underlying bug.
