### PR TITLE
setutils: cover __ge__'s double-complement branch, drop duplicated NotImplemented checks

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -818,8 +818,6 @@ class _ComplementSet:
         inc, exc = _norm_args_notimplemented(other)
         if inc is NotImplemented:
             return NotImplemented
-        if inc is NotImplemented:
-            return NotImplemented
         if self._included is None:
             if exc is None:  # - +
                 return False
@@ -833,8 +831,6 @@ class _ComplementSet:
 
     def __lt__(self, other):
         inc, exc = _norm_args_notimplemented(other)
-        if inc is NotImplemented:
-            return NotImplemented
         if inc is NotImplemented:
             return NotImplemented
         if self._included is None:

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -108,6 +108,16 @@ def test_complement_set():
     assert cab <= cab
     assert complement('a') >= cab
     assert cab >= cab
+    # double-complemented (included-form) sets dispatch to the + +
+    # branches of __le__/__ge__: comp(comp(X)) behaves like X
+    ccab = complement(complement(set('ab')))
+    cca = complement(complement(set('a')))
+    assert ccab >= cca
+    assert not (cca >= ccab)
+    assert cca <= ccab
+    assert not (ccab <= cca)
+    assert ccab >= ccab
+    assert ccab <= ccab
     assert not cab.isdisjoint(cc)  # complements never disjoint
     assert cab.isdisjoint(sab)
     assert not cab.isdisjoint(sc)


### PR DESCRIPTION
Two small followups to #438:

- **Close the test gap**: none of #438's assertions executed the fixed `__ge__` `+ +` branch — every `>=` case had an excluded-form complement on the left, dispatching through the `- -` branch (`issubset`, which was already correct). The `+ +` branch only runs when *both* sides are double-complemented (included-form). Added assertions using `complement(complement(set(...)))` on both sides, for `>=` and `<=`. Verified they execute the branch: temporarily replacing the branch body with a `raise` makes the new assertions fail.
- **Remove dead copy-paste**: `__le__` and `__lt__` each contained a duplicated `if inc is NotImplemented: return NotImplemented` immediately after the identical check.

Full suite: 468 passed.
