### PR TITLE
Fix Bits.__getitem__ returning False for every negative index

### DIFF
--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -170,7 +170,9 @@ class Bits:
         if type(k) is slice:
             return Bits(self.as_bin()[k])
         if type(k) is int:
-            if k >= self.len:
+            if k < 0:
+                k += self.len
+            if k < 0 or k >= self.len:
                 raise IndexError(k)
             return bool((1 << (self.len - k - 1)) & self.val)
         raise TypeError(type(k))

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -83,6 +83,11 @@ def test_bits():
     chk(Bits('10')[0], True)
     chk(Bits('10')[1], False)
     chk(Bits('0000100')[4], True)
+    chk(Bits('10')[-1], False)
+    chk(Bits('10')[-2], True)
+    chk(Bits('0000100')[-3], True)
+    with raises(IndexError):
+        Bits('10')[-3]
     chk(Bits('10').as_list(), [True, False])
     chk(Bits('10').as_int(), 2)
     chk(Bits('10').as_bin(), '10')


### PR DESCRIPTION
Noticed `bits[-1]` comes back `False` whatever's actually in there.

```python
>>> from boltons.mathutils import Bits
>>> b = Bits('1011')
>>> b[3]
True
>>> b[-1]      # same bit
False
>>> b[-2:]     # slices are fine
Bits('11')
>>> b[-99]     # no IndexError either
False
```

`__getitem__` only guards `k >= self.len`, so a negative `k` puts the mask above the top of the stored int and the AND always comes out 0. The slice branch escapes it because it goes through `as_bin()`.

I've matched the shape from d0a284f on `IndexedSet._get_real_index` rather than picking my own. Shout if you'd rather negatives just raised, easy swap.
