### PR TITLE
fix: correct GUIDerator size-bounds error message (20 is inclusive)

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -1473,7 +1473,7 @@ class GUIDerator:
     def __init__(self, size=24):
         self.size = size
         if size < 20 or size > 36:
-            raise ValueError('expected 20 < size <= 36')
+            raise ValueError('expected 20 <= size <= 36')
         import hashlib
         self._sha1 = hashlib.sha1
         self.count = itertools.count()

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -550,6 +550,19 @@ def test_guiderator():
     assert len(next(guid_iter)) == 26
 
 
+def test_guiderator_size_bounds():
+    import pytest
+    from boltons.iterutils import GUIDerator
+
+    # the documented lower bound (20) is inclusive and must work
+    assert len(next(GUIDerator(size=20))) == 20
+
+    # out-of-range sizes raise, with a message stating the real inclusive bounds
+    for bad in (19, 37):
+        with pytest.raises(ValueError, match=r"20 <= size <= 36"):
+            GUIDerator(size=bad)
+
+
 def test_seqguiderator():
     import string
     from boltons.iterutils import SequentialGUIDerator as GUIDerator


### PR DESCRIPTION
`GUIDerator.__init__` guards with `if size < 20 or size > 36`, so `size == 20` is accepted — and the docstring says "Lengths between 20 and 36 are considered valid". But the error message says `expected 20 < size <= 36`, excluding 20. So `GUIDerator(size=20)` succeeds while the message claims 20 is invalid.

Corrected the message to `20 <= size <= 36` to match the check and the docstring. Added a regression test covering the inclusive lower bound and the message.
