### PR TITLE
Add statsutils.mode() for the most common value

### DIFF
--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -30,7 +30,7 @@
 
 """``statsutils`` provides tools aimed primarily at descriptive
 statistics for data analysis, such as :func:`mean` (average),
-:func:`median`, :func:`variance`, and many others,
+:func:`median`, :func:`mode`, :func:`variance`, and many others,
 
 The :class:`Stats` type provides all the main functionality of the
 ``statsutils`` module. A :class:`Stats` object wraps a given dataset,
@@ -287,6 +287,27 @@ class Stats:
         """
         return self._get_quantile(self._get_sorted_data(), 0.5)
     median = _StatsProperty('median', _calc_median)
+
+    def _calc_mode(self):
+        """
+        The mode is the value that appears most frequently in the
+        data. Unlike the mean and median, the mode is well-defined for
+        non-numeric, categorical data, too.
+
+        >>> mode([2, 1, 3, 1])
+        1
+        >>> mode(['a', 'b', 'b', 'c', 'c', 'c'])
+        'c'
+
+        When several values are equally common, the one appearing
+        first in the data is returned, matching the standard library's
+        :func:`statistics.mode`.
+
+        >>> mode([1, 1, 2, 2, 3])
+        1
+        """
+        return Counter(self.data).most_common(1)[0][0]
+    mode = _StatsProperty('mode', _calc_mode)
 
     def _calc_iqr(self):
         """Inter-quartile range (IQR) is the difference between the 75th

--- a/tests/test_statsutils.py
+++ b/tests/test_statsutils.py
@@ -1,4 +1,4 @@
-from boltons.statsutils import Stats
+from boltons.statsutils import Stats, mode
 
 
 def test_stats_basic():
@@ -9,6 +9,16 @@ def test_stats_basic():
     assert da.skewness == 0
     assert round(da.kurtosis, 1) == 1.9
     assert da.median == 9.5
+
+
+def test_mode():
+    assert Stats([2, 1, 3, 1]).mode == 1
+    # ties resolve to the value seen first in the data
+    assert mode([1, 1, 2, 2, 3]) == 1
+    # non-numeric, categorical data is supported
+    assert mode(['a', 'b', 'b', 'c', 'c', 'c']) == 'c'
+    # empty data falls back to the configured default
+    assert Stats([], default=None).mode is None
 
 
 def _test_pearson():


### PR DESCRIPTION
Adds a `mode` measure to `statsutils`, closing #90.

`Stats` already exposes `mean` and `median` as central-tendency measures (each with a module-level convenience function), but there was no `mode`. This fills that gap.

Implementation follows the existing pattern exactly: `mode` is a `_StatsProperty` backed by `_calc_mode`, so it caches like the other measures and automatically gets a module-level `mode()` helper via the convenience-function loop. It uses the already-imported `collections.Counter`, so it works for non-numeric, categorical data as well as numbers:

```python
>>> from boltons.statsutils import mode, Stats
>>> mode([2, 1, 3, 1])
1
>>> mode(['a', 'b', 'b', 'c', 'c', 'c'])
'c'
>>> Stats(range(5)).mode
0
```

When several values are equally common, the one appearing first in the data is returned, matching the standard library's `statistics.mode`. Empty data falls back to the object's configured `default`, consistent with the other measures.

Added a `test_mode` case and doctests (which run under `--doctest-modules`); the module docstring's measure list now mentions `mode`. Full `test_statsutils` suite and doctests pass locally.