### PR TITLE
Use the sep argument in args2sh and args2cmd

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -798,7 +798,7 @@ def args2sh(args, sep=' '):
         # the string $'b is then quoted as '$'"'"'b'
         ret_list.append("'" + arg.replace("'", "'\"'\"'") + "'")
 
-    return ' '.join(ret_list)
+    return sep.join(ret_list)
 
 
 def args2cmd(args, sep=' '):
@@ -845,9 +845,9 @@ def args2cmd(args, sep=' '):
     for arg in args:
         bs_buf = []
 
-        # Add a space to separate this argument from the others
+        # Add the separator between this argument and the others
         if result:
-            result.append(' ')
+            result.append(sep)
 
         needquote = (" " in arg) or ("\t" in arg) or not arg
         if needquote:

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -363,3 +363,16 @@ def test_ellipsize():
         ellipsize('anything', 1)
     with pytest.raises(ValueError):
         ellipsize('anything', 3, ellipsis='...')
+
+
+def test_args2sh_sep():
+    assert strutils.args2sh(['aa', 'bb']) == 'aa bb'
+    assert strutils.args2sh(['aa', 'bb'], sep='|') == 'aa|bb'
+    # escaping is unaffected by the separator
+    assert strutils.args2sh(['a a', 'bb'], sep='|') == "'a a'|bb"
+
+
+def test_args2cmd_sep():
+    assert strutils.args2cmd(['aa', 'bb']) == 'aa bb'
+    assert strutils.args2cmd(['aa', 'bb'], sep='|') == 'aa|bb'
+    assert strutils.args2cmd(['a a', 'bb'], sep='|') == '"a a"|bb'


### PR DESCRIPTION
Both functions take `sep`, document it, and then hardcode a space.

```python
>>> args2sh(['aa', 'bb'], sep='|')
'aa bb'
>>> args2cmd(['aa', 'bb'], sep='|')
'aa bb'
```

`args2sh` ends with `' '.join(ret_list)`. `args2cmd` builds its output incrementally and appends a literal `' '` between arguments, under a comment saying it is separating them. Both docstrings say "separated by *sep*".

Two lines, using the argument that's already there. Escaping and quoting are untouched, so only the joining changes.

Tests are `test_args2sh_sep` and `test_args2cmd_sep`, each checking the default still gives a space, a custom separator is used, and an argument needing quotes still gets quoted around the new separator. Suite goes 469 to 471, and `--doctest-modules` is 152 passing. Reverting `strutils.py` fails both new tests and nothing else.

The existing doctests all use the default, which is why this held up so long.
