### PR TITLE
Pass encoding through to unquote in parse_qsl

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -964,9 +964,9 @@ def parse_qsl(qs, keep_blank_values=True, encoding=DEFAULT_ENCODING):
                 value = None
             else:
                 continue
-        key = unquote(key.replace('+', ' '))
+        key = unquote(key.replace('+', ' '), encoding=encoding)
         if value:
-            value = unquote(value.replace('+', ' '))
+            value = unquote(value.replace('+', ' '), encoding=encoding)
         ret.append((key, value))
     return ret
 

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -95,6 +95,16 @@ def test_query_params(test_url):
     assert test_url.endswith(qp_text)
 
 
+def test_parse_qsl_encoding():
+    # %E9 is 'e' with an acute accent in latin-1, and not valid utf-8
+    qs = 'k=%E9'
+    assert urlutils.parse_qsl(qs, encoding='latin-1') == [('k', '\xe9')]
+    # the default is unchanged: undecodable bytes become the replacement char
+    assert urlutils.parse_qsl(qs) == [('k', '\ufffd')]
+    # keys are decoded with the same encoding as values
+    assert urlutils.parse_qsl('%E9=v', encoding='latin-1') == [('\xe9', 'v')]
+
+
 def test_query_param_dict_eq_with_dict():
     qpd = QueryParamDict([('a', '1'), ('b', '2')])
     assert qpd == {'a': '1', 'b': '2'}


### PR DESCRIPTION
Same shape as #454, in `urlutils` this time. `parse_qsl` takes `encoding` and never passes it to `unquote`, so every query string is decoded as utf-8 whatever you ask for.

```python
>>> parse_qsl('k=%E9', encoding='latin-1')
[('k', '�')]
```

`%E9` is `é` in latin-1 and not valid utf-8, so the byte is replaced instead of decoded. With the argument threaded through it comes back as `[('k', 'é')]`.

The module's own `unquote` already takes `encoding`. So it is two call sites and no new machinery, on keys as well as values, since a key can carry an encoded byte too.

Nothing changes by default: `DEFAULT_ENCODING` is `'utf8'` and `unquote` defaults to `'utf-8'`, which is the same codec.

Test is `test_parse_qsl_encoding`, covering the latin-1 case and the unchanged default. Keys too. Suite goes 470 to 473 and `--doctest-modules` is 153 passing. Reverting `urlutils.py` fails that one test and nothing else.
