### PR TITLE
Make URL equality ignore query parameter order (#280)

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -800,9 +800,31 @@ class URL:
     def __unicode__(self):
         return self.to_text()
 
+    @staticmethod
+    def _norm_query_params(query_params):
+        "Normalize query params into an order-agnostic, comparable form."
+        if query_params is None:
+            return None
+        try:
+            items = list(query_params.items(multi=True))
+        except (AttributeError, TypeError):
+            try:
+                items = list(query_params.items())
+            except AttributeError:
+                return query_params
+        return sorted(items, key=lambda kv: (str(kv[0]), str(kv[1])))
+
     def __eq__(self, other):
         for attr in self._cmp_attrs:
-            if not getattr(self, attr) == getattr(other, attr, None):
+            self_val = getattr(self, attr)
+            other_val = getattr(other, attr, None)
+            if attr == 'query_params':
+                # query parameter order is not significant for equality
+                if (self._norm_query_params(self_val)
+                        != self._norm_query_params(other_val)):
+                    return False
+                continue
+            if not self_val == other_val:
                 return False
         return True
 

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -483,3 +483,13 @@ def test_unicodey():
 
 def test_str_repr():
     assert str(URL("http://googlewebsite.com/e-shops.aspx")) == "http://googlewebsite.com/e-shops.aspx"
+
+
+def test_url_eq_query_param_order():
+    # query parameter order does not affect equality; see issue #280
+    assert URL('http://example.com/?a=1&b=2') == URL('http://example.com/?b=2&a=1')
+    assert URL('http://example.com/?a=1&a=2') == URL('http://example.com/?a=2&a=1')
+    # different values are still unequal
+    assert URL('http://example.com/?a=1') != URL('http://example.com/?a=2')
+    # other components still participate in equality
+    assert URL('http://example.com/x?a=1') != URL('http://example.com/y?a=1')


### PR DESCRIPTION
URL.__eq__ compared query_params directly, so two URLs carrying the same parameters in a different order compared unequal, as reported in #280.

This normalizes query params to a sorted, order-agnostic form for the equality check only - all other URL components still participate in equality as before. Includes regression tests covering reordered params, repeated keys, and the still-unequal cases. Full test suite passes locally.

Disclosure: the initial fix was produced by an AI coding agent and then human-reviewed; tests verified locally.

Closes #280