### PR TITLE
Keep runs of capitals together in camel2under (#142)

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -63,7 +63,8 @@ __all__ = ['camel2under', 'under2camel', 'slugify', 'split_punct_ws',
 
 _punct_ws_str = string.punctuation + string.whitespace
 _punct_re = re.compile('[' + _punct_ws_str + ']+')
-_camel2under_re = re.compile('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))')
+_camel2under_acronym_re = re.compile('([A-Z]{2,})([A-Z][a-z])')
+_camel2under_re = re.compile('([a-z0-9])([A-Z])')
 
 
 def camel2under(camel_string):
@@ -72,8 +73,20 @@ def camel2under(camel_string):
 
     >>> camel2under('BasicParseTest')
     'basic_parse_test'
+
+    Runs of consecutive capital letters (e.g., acronyms like ``NS`` or
+    ``HTTPS``) are treated as a single word when they are immediately
+    followed by another capitalized word, and are otherwise kept
+    together, avoiding spurious underscores in the middle of short
+    acronyms such as ``UInt``.
+
+    >>> camel2under('NSDecimalToUInt')
+    'ns_decimal_to_uint'
+    >>> camel2under('HTTPSConnection')
+    'https_connection'
     """
-    return _camel2under_re.sub(r'_\1', camel_string).lower()
+    intermediate = _camel2under_acronym_re.sub(r'\1_\2', camel_string)
+    return _camel2under_re.sub(r'\1_\2', intermediate).lower()
 
 
 def under2camel(under_string):

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -327,6 +327,25 @@ def test_multi_replace_empty_mapping():
     assert strutils.multi_replace('foo bar', {}) == 'foo bar'
 
 
+def test_camel2under():
+    # unchanged behavior
+    assert strutils.camel2under('BasicParseTest') == 'basic_parse_test'
+    assert strutils.camel2under('HTTPServer') == 'http_server'
+    assert strutils.camel2under('getHTTPResponseCode') == 'get_http_response_code'
+    assert strutils.camel2under('XMLParser') == 'xml_parser'
+    assert strutils.camel2under('ABTest') == 'ab_test'
+    assert strutils.camel2under('AsciiToUTF8') == 'ascii_to_utf8'
+    assert strutils.camel2under('HTMLParser2') == 'html_parser2'
+    assert strutils.camel2under('iOS') == 'i_os'
+    assert strutils.camel2under('already_under') == 'already_under'
+
+    # #142: a run of capitals followed by lowercase letters is one word
+    assert strutils.camel2under('NSDecimalToUInt') == 'ns_decimal_to_uint'
+    assert strutils.camel2under('HTTPSConnection') == 'https_connection'
+    assert strutils.camel2under('UInt') == 'uint'
+    assert strutils.camel2under('TheIDs') == 'the_ids'
+
+
 def test_ellipsize():
     ellipsize = strutils.ellipsize
 


### PR DESCRIPTION
Fixes #142.

`camel2under('NSDecimalToUInt')` returned `'ns_decimal_to_u_int'`: the regex put an underscore before every capital that precedes a lowercase letter, which splits a run of capitals such as `UInt` into two words.

@mblahay asked for the precise rule, so here it is, implemented as two passes:

1. a run of two or more capitals followed by a capitalized word splits before that word — `HTTPSConnection → https_connection`, `XMLParser → xml_parser` (unchanged);
2. a run of capitals followed by lowercase letters stays one word — `UInt → uint`, `TheIDs → the_ids`, `NSDecimalToUInt → ns_decimal_to_uint` (**the change**).

Everything else behaves exactly as before (checked against the old regex on a probe set): `BasicParseTest`, `getHTTPResponseCode`, `ABTest → ab_test`, `AsciiToUTF8 → ascii_to_utf8`, `HTMLParser2`, `iOS → i_os`, `IOError → io_error`.

Re the `merge_single` flag idea from the thread: this change doesn't merge single capitals (`ABTest` is still `ab_test`, as it was), so I kept it flag-free; if you'd prefer the old splitting of `UInt`-style runs to stay reachable, I can add a keyword.

Adds doctest examples and `test_camel2under` covering the unchanged and changed cases. Full suite incl. doctests: 626 passed locally.

Authored with the help of an AI agent (Rookery Alpha), human-reviewed.