### PR TITLE
Fix addlist() dropping values from a one-shot iterable

### DIFF
--- a/boltons/dictutils.py
+++ b/boltons/dictutils.py
@@ -225,6 +225,9 @@ class OrderedMultiDict(dict):
         Called ``addlist`` for consistency with :meth:`getlist`, but
         tuples and other sequences and iterables work.
         """
+        # materialize first: the values are traversed twice below, and a
+        # one-shot iterator would be empty by the second pass
+        v = list(v)
         if not v:
             return
         self_insert = self._insert

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -1123,6 +1123,9 @@ class OrderedMultiDict(dict):
         Called ``addlist`` for consistency with :meth:`getlist`, but
         tuples and other sequences and iterables work.
         """
+        # materialize first: the values are traversed twice below, and a
+        # one-shot iterator would be empty by the second pass
+        v = list(v)
         if not v:
             return
         self_insert = self._insert

--- a/tests/test_dictutils.py
+++ b/tests/test_dictutils.py
@@ -270,6 +270,26 @@ def test_addlist():
     assert len(list(e_omd.iteritems(multi=True))) == 0
 
 
+def test_addlist_iterator():
+    # the docstring promises "tuples and other sequences and iterables work",
+    # and a one-shot iterator used to leave the OMD internally inconsistent
+    omd = OMD()
+    omd.addlist('a', iter([1, 2, 3]))
+    omd.addlist('b', (x for x in [4, 5]))
+
+    assert omd.keys() == ['a', 'b']
+    assert omd.getlist('a') == [1, 2, 3]
+    assert omd.getlist('b') == [4, 5]
+    assert omd.get('a') == 3
+    assert len(list(omd.iteritems(multi=True))) == 5
+
+    e_omd = OMD()
+    e_omd.addlist('a', (x for x in []))
+    assert len(e_omd) == 0
+    assert e_omd.keys() == []
+    assert e_omd.get('a') is None
+
+
 def test_pop_all():
     omd = OMD()
     omd.add('even', 0)


### PR DESCRIPTION
## The problem

`OrderedMultiDict.addlist` traverses its argument twice, so a one-shot iterator is empty by the second pass and every value is lost:

```python
from boltons.dictutils import OrderedMultiDict as OMD

omd = OMD()
omd.addlist('a', (x for x in [1, 2]))

omd            # OrderedMultiDict([('a', 1), ('a', 2)])
omd.getlist('a')   # []
omd.get('a')       # IndexError: list index out of range
```

The container is left internally inconsistent rather than merely wrong: the linked list recorded the keys, so `keys()`, `items(multi=True)` and `repr()` all show the values, while `getlist()` sees none of them. `get()` then indexes an empty list and raises — which is also at odds with its own docstring, "This method never raises a :exc:`KeyError`".

An empty iterator is worse, because the `if not v` guard is truthy for a generator:

```python
omd = OMD()
omd.addlist('a', (x for x in []))

len(omd)        # 1
omd.keys()      # []
'a' in omd      # True
```

`len()` disagreeing with `keys()` on a `dict` subclass is a hard invariant break.

This reaches the URL API too, since `QueryParamDict` inherits it:

```python
q = QueryParamDict()
q.addlist('a', (x for x in ['1', '2']))
q.to_text()      # 'a=1&a=2'
q.getlist('a')   # []
```

## Why it is a bug and not a documented limitation

The docstring promises the input may be an iterator:

> Called ``addlist`` for consistency with :meth:`getlist`, but tuples and other sequences and iterables work.
> — `boltons/dictutils.py:225`

Every idiomatic one-shot iterable hits it: generators, `map`, `filter`, `reversed`, `zip`, `iter(...)`. The doctest just above that line uses `range(3)`, which is re-iterable, which is why it has gone unnoticed.

## The fix

Materialize once, before the guard — so the two passes see the same values and `if not v` can judge an exhausted iterator correctly. One line at each of the two sites (`urlutils` carries a vendored copy of the method with the same defect).

## Tests

Added `test_addlist_iterator` alongside the existing `test_addlist`, covering `iter(...)`, a generator, and the empty-generator case. Verified by reverting only the source change and keeping the test: it fails with `assert [] == [1, 2, 3]`, and the other 29 tests in the file still pass, so it exercises this bug rather than `addlist` in general.

Full suite: 472 passing before, 473 after.

---

*Disclosure: this patch was prepared with AI assistance. The reproduction, the red/green check and the suite runs above were executed against this branch; happy to adjust anything on request.*
