### PR TITLE
fix: return all pairs from ThresholdCounter.most_common() when n is omitted

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -726,7 +726,7 @@ class ThresholdCounter:
         """Get the top *n* keys and counts as tuples. If *n* is omitted,
         returns all the pairs.
         """
-        if not n or n <= 0:
+        if n is not None and n <= 0:
             return []
         ret = sorted(self.iteritems(), key=lambda x: x[1], reverse=True)
         if n is None or n >= len(ret):

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -471,6 +471,9 @@ def test_threshold_counter():
     assert tc.get_uncommon_count() == 1  # bc the initial 1 was dropped
     assert round(tc.get_commonality(), 2) == 0.92
     assert tc.most_common(2) == [(2, 10), (5, 1)]
+    assert tc.most_common() == [(2, 10), (5, 1)]  # n omitted -> all pairs
+    assert tc.most_common(0) == []
+    assert tc.most_common(-1) == []
     assert list(tc.elements()) == ([2] * 10) + [5]
 
     assert tc[2] == 10


### PR DESCRIPTION
`ThresholdCounter.most_common()` returned `[]` instead of all pairs when *n* is omitted: the guard `if not n or n <= 0: return []` treats the default `n=None` as falsy and returns early — contradicting the docstring ("If *n* is omitted, returns all the pairs") and leaving the subsequent `if n is None ...` branch unreachable.

Guards only on an explicit non-positive `n`, so `most_common()` returns all pairs while `most_common(0)` / `most_common(-1)` still return `[]`. Extends `test_threshold_counter`.

Verified: on a populated counter `most_common()` now returns all pairs (was `[]`); zero/negative still return `[]`.

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
