### PR TITLE
Reject empty type and field names in namedutils

### DIFF
--- a/boltons/namedutils.py
+++ b/boltons/namedutils.py
@@ -160,10 +160,10 @@ def namedtuple(typename, field_names, verbose=False, rename=False):
                 field_names[index] = '_%d' % index
             seen.add(name)
     for name in [typename] + field_names:
-        if not all(c.isalnum() or c == '_' for c in name):
-            raise ValueError('Type names and field names can only contain '
-                             'alphanumeric characters and underscores: %r'
-                             % name)
+        if not name or not all(c.isalnum() or c == '_' for c in name):
+            raise ValueError('Type names and field names must be non-empty '
+                             'and can only contain alphanumeric characters '
+                             'and underscores: %r' % name)
         if _iskeyword(name):
             raise ValueError('Type names and field names cannot be a '
                              'keyword: %r' % name)
@@ -319,10 +319,10 @@ def namedlist(typename, field_names, verbose=False, rename=False):
                 field_names[index] = '_%d' % index
             seen.add(name)
     for name in [typename] + field_names:
-        if not all(c.isalnum() or c == '_' for c in name):
-            raise ValueError('Type names and field names can only contain '
-                             'alphanumeric characters and underscores: %r'
-                             % name)
+        if not name or not all(c.isalnum() or c == '_' for c in name):
+            raise ValueError('Type names and field names must be non-empty '
+                             'and can only contain alphanumeric characters '
+                             'and underscores: %r' % name)
         if _iskeyword(name):
             raise ValueError('Type names and field names cannot be a '
                              'keyword: %r' % name)

--- a/tests/test_namedutils.py
+++ b/tests/test_namedutils.py
@@ -1,5 +1,7 @@
 from pickle import loads, dumps
 
+import pytest
+
 from boltons.namedutils import namedlist, namedtuple
 
 Point = namedtuple('Point', 'x, y', rename=True)
@@ -24,3 +26,29 @@ def test_namedlist_pickle():
 def test_namedtuple_pickle():
     p = Point(x=10, y=20)
     assert p == loads(dumps(p))
+
+
+@pytest.mark.parametrize("factory", [namedtuple, namedlist])
+def test_empty_field_name_raises_value_error(factory):
+    # `all()` is True for the empty string, so an empty name used to pass both
+    # ValueError checks and reach `name[0].isdigit()`, raising IndexError.
+    with pytest.raises(ValueError):
+        factory('Point', ['x', ''])
+
+
+@pytest.mark.parametrize("factory", [namedtuple, namedlist])
+def test_empty_type_name_raises_value_error(factory):
+    with pytest.raises(ValueError):
+        factory('', ['x', 'y'])
+
+
+@pytest.mark.parametrize("factory", [namedtuple, namedlist])
+def test_invalid_character_still_raises_value_error(factory):
+    with pytest.raises(ValueError):
+        factory('Point', ['x', 'y-z'])
+
+
+@pytest.mark.parametrize("factory", [namedtuple, namedlist])
+def test_valid_names_still_accepted(factory):
+    cls = factory('Point', ['x', 'y'])
+    assert cls(x=1, y=2).x == 1


### PR DESCRIPTION
The validation loop in `namedtuple` and `namedlist` checks names with:

```python
if not all(c.isalnum() or c == "_" for c in name):
```

`all()` returns `True` for an empty iterable, so an empty name passes this check. It then passes `_iskeyword("")` as well, and reaches `name[0].isdigit()` — which raises `IndexError` instead of the intended `ValueError`:

```
=== boltons.namedutils.namedtuple ===
  empty field name ["x", ""]     -> IndexError: string index out of range
  empty typename ""              -> IndexError: string index out of range
  control: invalid char ["x-y"]  -> ValueError: Type names and field names can only contain
                                    alphanumeric characters and underscores: "x-y"
  control: valid ["x", "y"]      -> accepted
=== boltons.namedutils.namedlist ===
  empty field name ["x", ""]     -> IndexError: string index out of range
  empty typename ""              -> IndexError: string index out of range
```

Both factories are affected, and both an empty field name and an empty typename trigger it.

### Why this looks like an oversight rather than a decision

The `rename` branch seven lines above the validation loop already guards for this exact case:

```python
if (not all(c.isalnum() or c == "_" for c in name)
    or _iskeyword(name)
    or not name                     # <-- here
    or name[0].isdigit()
    ...
```

So the guard exists in the same function; it is just missing from the loop that raises. `CPython`s `collections.namedtuple`, which this module is a variant of, rejects the same input properly:

```
=== CPython collections.namedtuple ===
  empty field name ["x", ""]     -> ValueError: Type names and field names must be valid identifiers: ""
  empty typename ""              -> ValueError: Type names and field names must be valid identifiers: ""
```

### The change

Adds `or not name` to the validation loop in both functions, matching the form the rename branch already uses.

I also extended the message. The existing wording — "can only contain alphanumeric characters and underscores" — is vacuously true of the empty string: it states a rule the empty string does not actually break, so it would not explain the failure. The new wording is "must be non-empty and can only contain alphanumeric characters and underscores". No test asserted on the old text. Happy to drop that part and keep the one-word condition change if you would rather leave the message alone.

The `rename=True` branches are untouched.

### Tests

Added to `tests/test_namedutils.py`, parametrized over both factories: empty field name, empty typename, an invalid character (still `ValueError`), and a valid pair (still accepted).

Verified the tests pin the behaviour rather than just passing — against an unmodified `namedutils.py` the four empty-name cases fail with the `IndexError` above:

```
FAILED tests/test_namedutils.py::test_empty_field_name_raises_value_error[namedtuple]
FAILED tests/test_namedutils.py::test_empty_field_name_raises_value_error[namedlist]
FAILED tests/test_namedutils.py::test_empty_type_name_raises_value_error[namedtuple]
FAILED tests/test_namedutils.py::test_empty_type_name_raises_value_error[namedlist]
4 failed, 7 passed
```

With the fix, and using the command from `tox.ini`:

```
pytest --doctest-modules boltons/namedutils.py tests/test_namedutils.py
13 passed

pytest tests
480 passed
```

### Conflicts

#382 also touches `boltons/namedutils.py`, but its hunks are at lines 45, 120-122 and 279-281, while this change is at 163 and 322 — no overlap.