### PR TITLE
Honor the encoding when reading lines in reverse

### DIFF
--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -72,13 +72,7 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
 
     """
     # This function is a bit of a pain because it attempts to be byte/text agnostic
-    try:
-        encoding = encoding or file_obj.encoding
-    except AttributeError:
-        # BytesIO
-        encoding = None
-    else:
-        encoding = 'utf-8'
+    encoding = encoding or getattr(file_obj, 'encoding', None)
 
     # need orig_obj to keep alive otherwise __del__ on the TextWrapper will close the file
     orig_obj = file_obj

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -81,3 +81,20 @@ def test_jsonl_iterator_rel_seek_negative():
     assert tail
     assert tail == list(JSONLIterator(open(JSONL_DATA_PATH), rel_seek=0.5))
     assert tail == ref[len(ref) - len(tail):]
+
+
+def test_reverse_iter_lines_uses_file_encoding(tmp_path):
+    from io import TextIOWrapper
+
+    path = tmp_path / 'latin1.txt'
+    path.write_bytes('café\nfin'.encode('latin-1'))
+    with path.open('rb') as raw:
+        stream = TextIOWrapper(raw, encoding='latin-1')
+        assert list(reverse_iter_lines(stream)) == ['fin', 'café']
+
+
+def test_reverse_iter_lines_uses_explicit_binary_encoding():
+    from io import BytesIO
+
+    stream = BytesIO('café\nfin'.encode('latin-1'))
+    assert list(reverse_iter_lines(stream, encoding='latin-1')) == ['fin', 'café']


### PR DESCRIPTION
`reverse_iter_lines()` overwrites a text stream's encoding with UTF-8 and drops an explicit encoding for binary streams. Use the supplied encoding, falling back to the stream's encoding when available.

Adds Latin-1 text-stream and binary-stream regression tests.
