### PR TITLE
Support relative seeking in binary JSONL streams

### DIFF
--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -176,9 +176,10 @@ class JSONLIterator:
     def _align_to_newline(self):
         "Aligns the file object's position to the next newline."
         fo, bsize = self._file_obj, self._blocksize
-        cur, total_read = '', 0
+        newline = b'\n' if isinstance(fo.read(0), bytes) else '\n'
+        cur, total_read = newline[:0], 0
         cur_pos = fo.tell()
-        while '\n' not in cur:
+        while newline not in cur:
             cur = fo.read(bsize)
             if not cur:
                 # no newline until EOF; a partial trailing line was
@@ -186,7 +187,7 @@ class JSONLIterator:
                 fo.seek(0, os.SEEK_END)
                 return
             total_read += bsize
-        newline_offset = cur.index('\n') + total_read - bsize
+        newline_offset = cur.index(newline) + total_read - bsize
         fo.seek(cur_pos + newline_offset)
 
     def _init_rel_seek(self):

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -81,3 +81,10 @@ def test_jsonl_iterator_rel_seek_negative():
     assert tail
     assert tail == list(JSONLIterator(open(JSONL_DATA_PATH), rel_seek=0.5))
     assert tail == ref[len(ref) - len(tail):]
+
+
+def test_jsonl_relative_seek_binary_matches_text(tmp_path):
+    path = tmp_path / 'records.jsonl'
+    path.write_bytes(b'{"n": 1}\n{"n": 2}\n{"n": 3}\n')
+    with path.open('rb') as binary, path.open() as text:
+        assert list(JSONLIterator(binary, rel_seek=0.4)) == list(JSONLIterator(text, rel_seek=0.4))


### PR DESCRIPTION
Relative seeking checks for a string newline in bytes read from binary files, raising `TypeError`. Match the newline type to the stream before aligning the cursor.

Adds a regression comparing binary and text JSONL seeks.
