### PR TITLE
Keep text streams usable after reverse iteration

### DIFF
--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -83,7 +83,7 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
     # need orig_obj to keep alive otherwise __del__ on the TextWrapper will close the file
     orig_obj = file_obj
     try:
-        file_obj = orig_obj.detach()
+        file_obj = orig_obj.buffer
     except (AttributeError, io.UnsupportedOperation):
         pass
 

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -81,3 +81,12 @@ def test_jsonl_iterator_rel_seek_negative():
     assert tail
     assert tail == list(JSONLIterator(open(JSONL_DATA_PATH), rel_seek=0.5))
     assert tail == ref[len(ref) - len(tail):]
+
+
+def test_reverse_iter_lines_keeps_text_stream_attached(tmp_path):
+    path = tmp_path / 'lines.txt'
+    path.write_text('first\nsecond')
+    with path.open() as stream:
+        assert list(reverse_iter_lines(stream)) == ['second', 'first']
+        stream.seek(0)
+        assert stream.read() == 'first\nsecond'


### PR DESCRIPTION
Reverse iteration detaches the buffer from a caller-owned text stream. This makes later reads and even exiting its `with` block raise `ValueError`. Read from the existing buffer without detaching it.

Adds a regression that reverses, seeks, reads, and closes the same text stream.
