### PR TITLE
Handle zero interquartile range in automatic histograms

### DIFF
--- a/boltons/statsutils.py
+++ b/boltons/statsutils.py
@@ -561,6 +561,8 @@ class Stats:
             # freedman algorithm for fixed-width bin selection
             q25, q75 = self.get_quantile(0.25), self.get_quantile(0.75)
             dx = 2 * (q75 - q25) / (len_data ** (1 / 3.0))
+            if dx == 0:
+                return [float(min_data), float(max_data)] if with_max else [float(min_data)]
             bin_count = max(1, int(ceil((max_data - min_data) / dx)))
             bins = [min_data + (dx * i) for i in range(bin_count + 1)]
             bins = [b for b in bins if b < max_data]

--- a/tests/test_statsutils.py
+++ b/tests/test_statsutils.py
@@ -40,3 +40,10 @@ def _test_pearson():
         print('pearson type:', pt)
 
         # import pdb;pdb.set_trace()
+
+
+def test_histogram_zero_interquartile_range():
+    for data in ([5] * 10, [0] * 10 + [100]):
+        counts = Stats(data).get_histogram_counts()
+        assert counts == [(float(min(data)), len(data))]
+        assert Stats(data).format_histogram()


### PR DESCRIPTION
Automatic histogram bins divide by zero when the interquartile range is zero, including constant datasets. Fall back to one bin spanning the data when the Freedman width is zero.

Adds regressions for constant values and a repeated value with an outlier.
