### PR TITLE
Preserve empty Bits across binary and byte conversions

### DIFF
--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -206,9 +206,13 @@ class Bits:
         return [c == '1' for c in self.as_bin()]
 
     def as_bin(self):
+        if not self.len:
+            return ''
         return f'{{0:0{self.len}b}}'.format(self.val)
 
     def as_hex(self):
+        if not self.len:
+            return ''
         # make template to pad out to number of bytes necessary to represent bits
         tmpl = f'%0{2 * (self.len // 8 + ((self.len % 8) != 0))}X'
         ret = tmpl % self.val
@@ -232,6 +236,8 @@ class Bits:
     def from_hex(cls, hex):
         if isinstance(hex, bytes):
             hex = hex.decode('ascii')
+        if not hex:
+            return cls('')
         if not hex.startswith('0x'):
             hex = '0x' + hex
         return cls(hex)

--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -236,7 +236,7 @@ class Bits:
     def from_hex(cls, hex):
         if isinstance(hex, bytes):
             hex = hex.decode('ascii')
-        if not hex:
+        if hex == '':
             return cls('')
         if not hex.startswith('0x'):
             hex = '0x' + hex

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -122,3 +122,15 @@ def test_bits_len_bound():
         Bits(4, 2)
     with raises(ValueError):
         Bits(1, 0)
+
+
+def test_empty_bits_conversions():
+    for bits in (Bits(''), Bits([]), Bits('101')[:0], Bits(0, 0)):
+        assert len(bits) == 0
+        assert bits.as_bin() == ''
+        assert bits.as_list() == []
+        assert bits.as_hex() == ''
+        assert bits.as_bytes() == b''
+        assert Bits.from_bin(bits.as_bin()) == bits
+        assert Bits.from_hex(bits.as_hex()) == bits
+        assert Bits.from_bytes(bits.as_bytes()) == bits

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -134,3 +134,9 @@ def test_empty_bits_conversions():
         assert Bits.from_bin(bits.as_bin()) == bits
         assert Bits.from_hex(bits.as_hex()) == bits
         assert Bits.from_bytes(bits.as_bytes()) == bits
+
+
+def test_empty_bits_rejects_non_hex_inputs():
+    for value in (None, 0, False):
+        with raises(AttributeError):
+            Bits.from_hex(value)


### PR DESCRIPTION
An empty `Bits` value serializes as a one-bit zero, while byte conversion raises an odd-length hex error. Preserve the empty representation and allow empty hex and byte inputs to round-trip.

Adds coverage for empty constructors, slices, and all conversion paths.
