### PR TITLE
Reject BarrelList item indexes past the end

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -114,6 +114,8 @@ class BarrelList(list):
             if rel_idx < len_list:
                 break
             rel_idx -= len_list
+        else:
+            rel_idx += len(lists[-1])
         if rel_idx < 0:
             return None, None
         return list_idx, rel_idx

--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -138,3 +138,25 @@ bl.extend(range(int(%s)))
     except Exception as e:
         import pdb;pdb.post_mortem()
         raise
+
+
+def test_barrellist_out_of_bounds_indexes():
+    import operator
+    import pytest
+
+    for parts in ([[0, 1, 2]], [[0], [1, 2]]):
+        for index in (3, 4, 10, -4):
+            for operation in (
+                operator.getitem,
+                operator.delitem,
+                lambda obj, i: operator.setitem(obj, i, 99),
+                lambda obj, i: obj.pop(i),
+            ):
+                value = BarrelList()
+                value.lists = [part[:] for part in parts]
+                with pytest.raises(IndexError):
+                    operation(value, index)
+                assert list(value) == [0, 1, 2]
+    value = BarrelList([0, 1, 2])
+    value.insert(100, 3)
+    assert list(value) == [0, 1, 2, 3]


### PR DESCRIPTION
Index translation subtracts the final barrel's length even when no barrel contains the requested index. As a result, reading or deleting at `len(value)` can target an existing item. Keep the final relative index out of bounds so normal list errors apply.

Adds read, write, delete, pop, and insertion regressions.
