### PR TITLE
Normalize BarrelList slice bounds and reverse steps

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -168,23 +168,11 @@ class BarrelList(list):
         return ret
 
     def iter_slice(self, start, stop, step=None):
-        iterable = self  # TODO: optimization opportunities abound
-        # start_list_idx, stop_list_idx = 0, len(self.lists)
-        if start is None:
-            start = 0
-        if stop is None:
-            stop = len(self)
-        if step is not None and step < 0:
-            step = -step
-            start, stop = -start, -stop - 1
-            iterable = reversed(self)
-        if start < 0:
-            start += len(self)
-            # start_list_idx, start_rel_idx = self._translate_index(start)
-        if stop < 0:
-            stop += len(self)
-            # stop_list_idx, stop_rel_idx = self._translate_index(stop)
-        return islice(iterable, start, stop, step)
+        length = len(self)
+        start, stop, step = slice(start, stop, step).indices(length)
+        if step < 0:
+            return islice(reversed(self), length - 1 - start, length - 1 - stop, -step)
+        return islice(self, start, stop, step)
 
     def del_slice(self, start, stop, step=None):
         if step is not None and abs(step) > 1:  # punt

--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -138,3 +138,19 @@ bl.extend(range(int(%s)))
     except Exception as e:
         import pdb;pdb.post_mortem()
         raise
+
+
+def test_barrellist_slicing_matches_list():
+    import itertools
+    import pytest
+
+    for size in (0, 1, 8):
+        reference = list(range(size))
+        value = BarrelList(reference)
+        for start, stop, step in itertools.product(
+            (None, -20, -2, 0, 2, 20), (None, -20, -2, 0, 2, 20), (None, -3, -1, 1, 2)
+        ):
+            key = slice(start, stop, step)
+            assert list(value[key]) == reference[key], key
+        with pytest.raises(ValueError):
+            value[::0]


### PR DESCRIPTION
Reverse slicing misinterprets explicit bounds, while large negative bounds can reach `islice()` without being clamped. Normalize with `slice.indices()` before translating a reverse slice.

Compares positive and negative slices against Python lists, including empty inputs and out-of-range bounds.
