### PR TITLE
Keep the stop barrel valid during cross-barrel deletion

### DIFF
--- a/boltons/listutils.py
+++ b/boltons/listutils.py
@@ -207,9 +207,9 @@ class BarrelList(list):
         if start_list_idx == stop_list_idx:
             del self.lists[start_list_idx][start_rel_idx:stop_rel_idx]
         elif start_list_idx < stop_list_idx:
-            del self.lists[start_list_idx + 1:stop_list_idx]
-            del self.lists[start_list_idx][start_rel_idx:]
             del self.lists[stop_list_idx][:stop_rel_idx]
+            del self.lists[start_list_idx][start_rel_idx:]
+            del self.lists[start_list_idx + 1:stop_list_idx]
         else:
             assert False, ('start list index should never translate to'
                            ' greater than stop list index')

--- a/tests/test_listutils.py
+++ b/tests/test_listutils.py
@@ -138,3 +138,14 @@ bl.extend(range(int(%s)))
     except Exception as e:
         import pdb;pdb.post_mortem()
         raise
+
+
+def test_barrellist_delete_across_multiple_barrels():
+    for start, stop in ((2, 10), (1, 7), (4, 10), (2, 4)):
+        reference = list(range(12))
+        value = BarrelList()
+        value.lists = [reference[i : i + 3] for i in range(0, 12, 3)]
+        del reference[start:stop]
+        del value[start:stop]
+        assert list(value) == reference
+        assert len(value) == len(reference)


### PR DESCRIPTION
Deleting intermediate barrels shifts the stop barrel before its prefix is removed, causing an `IndexError` or deleting from the wrong barrel. Trim both endpoints before removing intermediate barrels.

Adds deletion regressions spanning adjacent and multiple barrels.
