### PR TITLE
Fix IndexedSet.update with multiple iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ scheme (`YY.MINOR.MICRO`).
 
 _(unreleased)_
 
+- Fixed [`setutils.IndexedSet`][setutils.IndexedSet] updating from multiple iterables to add their elements instead of the iterables themselves
 - Added [`strutils.ellipsize`][strutils.ellipsize] for word-boundary-aware text truncation with an ellipsis
 - Fixed [`funcutils.wraps`][funcutils.wraps] passing arguments positionally to wrappers that only accept them as keywords ([#261](https://github.com/mahmoud/boltons/issues/261))
 - Fixed [`tableutils.Table.to_text`][tableutils.Table] crashes on empty tables, `None` headers, and short header rows; empty headers now render no header row, matching `to_html`

--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -349,7 +349,7 @@ class IndexedSet(MutableSet):
         elif len(others) == 1:
             other = others[0]
         else:
-            other = chain(others)
+            other = chain.from_iterable(others)
         for o in other:
             self.add(o)
 

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -1,4 +1,4 @@
-from pytest import raises
+from pytest import mark, raises
 
 from boltons.setutils import IndexedSet, _MISSING, complement
 
@@ -26,6 +26,25 @@ def test_indexed_set_rsub():
     assert (set('abc') - IndexedSet('bcd')) == {'a'}
     assert (IndexedSet('abc') - IndexedSet('bcd')) == IndexedSet(['a'])
     assert (frozenset('abc') - IndexedSet('bcd')) == frozenset(['a'])
+
+
+@mark.parametrize('iterable_type', [list, tuple, iter])
+def test_indexed_set_update_multiple_iterables(iterable_type):
+    items = IndexedSet([1])
+
+    result = items.update(iterable_type([2, 1, 3]), iterable_type([]),
+                          iterable_type([3, 4, 2]))
+
+    assert result is None
+    assert list(items) == [1, 2, 3, 4]
+
+
+def test_indexed_set_update_multiple_iterables_with_tuple_items():
+    items = IndexedSet()
+
+    items.update([(1, 2)], [(3, 4), (1, 2)])
+
+    assert list(items) == [(1, 2), (3, 4)]
 
 
 def test_indexed_set_mutate():


### PR DESCRIPTION
`IndexedSet.update()` documents support for one or more iterables, but the multiple-argument branch adds the iterables themselves. For example, `IndexedSet([1]).update([2], [3])` raises `TypeError`, while tuple and iterator arguments silently become set members.

Flatten the arguments by one level with `chain.from_iterable`, preserving insertion order and duplicate removal. Add regression coverage for lists, tuples, one-shot iterators, empty arguments, and tuple-valued elements.

Validation: all four new cases failed on the original code; `python -m pytest --doctest-modules boltons tests -q` passes with **629 tests** on Python 3.13.14. `git diff --check` passes.

Checked related open and closed IndexedSet/update PRs before implementation; #440 and #443 do not cover this multiple-argument path.

Prepared with Codex assistance and independently reviewed.