### PR TITLE
Fix Unicode line separators in iter_splitlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ scheme (`YY.MINOR.MICRO`).
 
 _(unreleased)_
 
+- Fixed [`strutils.iter_splitlines`][strutils.iter_splitlines] and [`strutils.indent`][strutils.indent] recognizing Unicode line separators instead of splitting on spaces followed by `28` or `29`
 - Added [`strutils.ellipsize`][strutils.ellipsize] for word-boundary-aware text truncation with an ellipsis
 - Fixed [`funcutils.wraps`][funcutils.wraps] passing arguments positionally to wrappers that only accept them as keywords ([#261](https://github.com/mahmoud/boltons/issues/261))
 - Fixed [`tableutils.Table.to_text`][tableutils.Table] crashes on empty tables, `None` headers, and short header rows; empty headers now render no header row, matching `to_html`

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -662,7 +662,7 @@ def gzip_bytes(bytestring, level=6):
 
 
 
-_line_ending_re = re.compile(r'(\r\n|\n|\x0b|\f|\r|\x85|\x2028|\x2029)',
+_line_ending_re = re.compile(r'(\r\n|\n|\x0b|\f|\r|\x85|\u2028|\u2029)',
                              re.UNICODE)
 
 

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -52,6 +52,26 @@ def test_indent():
     assert strutils.indent(to_indent, '  ') == ref
 
 
+@pytest.mark.parametrize('line_ending', ['\u2028', '\u2029'])
+def test_iter_splitlines_unicode_line_endings(line_ending):
+    text = line_ending + 'first' + line_ending + 'second' + line_ending
+
+    assert list(strutils.iter_splitlines(text)) == ['', 'first', 'second', '']
+
+
+def test_iter_splitlines_preserves_numbers_after_spaces():
+    text = 'February 28, or February 29 in a leap year'
+
+    assert list(strutils.iter_splitlines(text)) == [text]
+
+
+def test_indent_unicode_line_endings():
+    text = 'February 28\u2028February 29\u2029March 1\r\nMarch 2'
+
+    assert strutils.indent(text, '  ') == (
+        '  February 28\n  February 29\n  March 1\n  March 2')
+
+
 def test_is_uuid():
     assert strutils.is_uuid(uuid.uuid4()) == True
     assert strutils.is_uuid(uuid.uuid4(), version=1) == False


### PR DESCRIPTION
`iter_splitlines()` uses `\x2028` and `\x2029` in its line-ending pattern. A hex escape consumes only two digits, so these match a space followed by `28` or `29` instead of the Unicode line and paragraph separators. For example, `list(iter_splitlines('February 28, 2026'))` returns `['February', ', 2026']`, and `indent()` inherits the same text corruption.

Use `\u2028` and `\u2029` for the intended characters. Add regressions for both Unicode separators, leading/trailing separators, ordinary text containing `28` and `29`, and indentation with mixed line endings.

Validation: all four new cases failed on the original code; `python -m pytest --doctest-modules boltons tests -q` passes with **629 tests** on Python 3.13.14. `git diff --check` passes.

Checked related open and closed line-ending, splitlines and indentation PRs before implementation; no matching fix was found.

Prepared with Codex assistance and independently reviewed.