### PR TITLE
Honor mapping counts in ThresholdCounter.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ scheme (`YY.MINOR.MICRO`).
 
 _(unreleased)_
 
+- Fixed [`cacheutils.ThresholdCounter.update`][cacheutils.ThresholdCounter] ignoring counts supplied in Python 3 mappings and keyword arguments
 - Added [`strutils.ellipsize`][strutils.ellipsize] for word-boundary-aware text truncation with an ellipsis
 - Fixed [`funcutils.wraps`][funcutils.wraps] passing arguments positionally to wrappers that only accept them as keywords ([#261](https://github.com/mahmoud/boltons/issues/261))
 - Fixed [`tableutils.Table.to_text`][tableutils.Table] crashes on empty tables, `None` headers, and short header rows; empty headers now render no header row, matching `to_html`

--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -802,8 +802,11 @@ class ThresholdCounter:
         to integer counts.
         """
         if iterable is not None:
-            if callable(getattr(iterable, 'iteritems', None)):
-                for key, count in iterable.iteritems():
+            items = getattr(iterable, 'iteritems', None)
+            if not callable(items):
+                items = getattr(iterable, 'items', None)
+            if callable(items):
+                for key, count in items():
                     for i in range(count):
                         self.add(key)
             else:

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -1,6 +1,7 @@
 import string
 import sys
 from abc import abstractmethod, ABCMeta
+from collections import UserDict
 
 import pytest
 
@@ -478,3 +479,61 @@ def test_threshold_counter():
     assert sorted(tc.keys()) == [2, 5]
     assert sorted(tc.values()) == [1, 10]
     assert sorted(tc.items()) == [(2, 10), (5, 1)]
+
+
+@pytest.mark.parametrize('mapping_type', [dict, UserDict])
+def test_threshold_counter_update_mapping_counts(mapping_type):
+    tc = ThresholdCounter()
+    tc.add('a')
+
+    assert tc.update(mapping_type(a=3, b=2, zero=0)) is None
+
+    assert dict(tc.items()) == {'a': 4, 'b': 2}
+    assert tc.total == 6
+    assert 'zero' not in tc
+
+
+@pytest.mark.parametrize('source', [None, ['a']])
+def test_threshold_counter_update_keyword_counts(source):
+    tc = ThresholdCounter()
+    tc.update(source, a=3, b=2, zero=0)
+
+    expected_a = 3 if source is None else 4
+    assert dict(tc.items()) == {'a': expected_a, 'b': 2}
+    assert tc.total == expected_a + 2
+
+
+def test_threshold_counter_update_legacy_mapping():
+    class LegacyMapping:
+        def iteritems(self):
+            return iter([('a', 3), ('zero', 0)])
+
+    tc = ThresholdCounter()
+    tc.update(LegacyMapping())
+
+    assert tc.items() == [('a', 3)]
+    assert tc.total == 3
+
+
+def test_threshold_counter_update_iterable_tuple_keys():
+    tc = ThresholdCounter()
+    tc.update(iter([('a', 3), ('a', 3), ('b', 2)]))
+
+    assert dict(tc.items()) == {('a', 3): 2, ('b', 2): 1}
+    assert tc.total == 3
+
+
+@pytest.mark.parametrize('threshold', [0.1, 0.25])
+def test_threshold_counter_update_mapping_compaction(threshold):
+    tc = ThresholdCounter(threshold=threshold)
+    expected = ThresholdCounter(threshold=threshold)
+    tc.add('rare')
+    expected.add('rare')
+
+    tc.update({'a': 10, 'b': 5})
+    expected.update(['a'] * 10 + ['b'] * 5)
+
+    assert dict(tc.items()) == dict(expected.items())
+    assert tc.total == expected.total == 16
+    assert tc.get_common_count() == expected.get_common_count()
+    assert tc.get_uncommon_count() == expected.get_uncommon_count()


### PR DESCRIPTION
`ThresholdCounter.update()` documents accepting mappings of keys to integer counts, but it recognizes only the Python 2-style `iteritems()` method. On Python 3, `update({'a': 3, 'zero': 0})` counts each key once, producing `a=1`, `zero=1`, and an incorrect total. Keyword counts are affected through the same path.

Accept callable `items()` when `iteritems()` is unavailable, preserving existing legacy inputs and the per-occurrence `add()` calls that drive threshold compaction.

Add eight regression and control cases covering dict/UserDict inputs, additive counts, zero counts, keyword counts after an iterable, legacy mappings, tuple-valued keys, and equivalence to an expanded stream across compaction thresholds.

Validation: six new regression cases failed before the fix and two compatibility controls passed. `python -m pytest --doctest-modules boltons tests -q`: **633 passed** on Python 3.13.14. `git diff --check` passed.

Checked related open and closed PRs before implementation. #460 changes `most_common()` only, and #382 only adds annotations to this method; neither fixes mapping updates.

Prepared with Codex assistance and independently reviewed.