### PR TITLE
Fix URL serialization with a password and empty username

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -721,7 +721,7 @@ class URL:
         """
         parts = []
         _add = parts.append
-        if self.username and with_userinfo:
+        if with_userinfo and (self.username or self.password):
             _add(quote_userinfo_part(self.username))
             if self.password:
                 _add(':')

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -189,6 +189,18 @@ def test_userinfo():
     assert url.to_text() == 'http://someuser:somepassword@example.com/some-segment@ignore'
 
 
+def test_password_without_username():
+    url = URL('http://:secret@example.com/path')
+    assert url.username == ''
+    assert url.password == 'secret'
+    assert url.to_text() == 'http://:secret@example.com/path'
+    assert url.get_authority(with_userinfo=True) == ':secret@example.com'
+    assert url.get_authority() == 'example.com'
+
+    url.password = 'p@ss'
+    assert url.to_text(full_quote=True) == 'http://:p%40ss@example.com/path'
+
+
 def test_quoted_userinfo():
     url = URL('http://wikipedia.org')
     url.username = 'user'


### PR DESCRIPTION
URL.to_text() currently drops user information when a password is present but the username is empty. For example, `URL('http://:secret@example.com/path').to_text()` becomes `http://example.com/path`.

Include user information when either a username or a password is present. The default get_authority() output continues to omit user information. Add a regression test covering serialization, explicit authority output, default authority output, and an escaped password.

Validation: the regression test failed on the original code; `python -m pytest tests/test_urlutils.py --doctest-modules boltons/urlutils.py -q` passes all 137 tests after the fix.

Prepared with OpenAI Codex assistance.
