### PR TITLE
Support empty and keyword-only LRI and LRU updates

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -293,11 +293,11 @@ class LRI(dict):
                 self[key] = default
                 return default
 
-    def update(self, E, **F):
+    def update(self, E=(), **F):
         # E and F are throwback names to the dict() __doc__
         with self._lock:
             if E is self:
-                return
+                E = ()
             setitem = self.__setitem__
             if callable(getattr(E, 'keys', None)):
                 for k in E.keys():

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -166,6 +166,56 @@ def test_lru_basic():
     assert second_lru != lru
 
 
+@pytest.mark.parametrize('cache_type, expected', [
+    (LRI, {'b': 2, 'c': 3}),
+    (LRU, {'a': 1, 'c': 3}),
+])
+def test_cache_update_no_args(cache_type, expected):
+    cache = cache_type(max_size=2, values=[('a', 1), ('b', 2)])
+    assert cache['a'] == 1
+
+    assert cache.update() is None
+    assert cache.update(cache) is None
+    assert (cache.hit_count, cache.miss_count, cache.soft_miss_count) == (1, 0, 0)
+
+    cache['c'] = 3
+    assert dict(cache) == expected
+
+
+@pytest.mark.parametrize('cache_type', [LRI, LRU])
+@pytest.mark.parametrize('with_self', [False, True])
+def test_cache_update_keywords(cache_type, with_self):
+    cache = cache_type(max_size=2, values=[('a', 1), ('b', 2)])
+
+    if with_self:
+        result = cache.update(cache, a=3, c=4)
+    else:
+        result = cache.update(a=3, c=4)
+
+    assert result is None
+    assert dict(cache) == {'a': 3, 'c': 4}
+    assert cache['a'] == 3
+    assert cache['c'] == 4
+
+    cache['d'] = 5
+    assert dict(cache) == {'c': 4, 'd': 5}
+
+
+@pytest.mark.parametrize('cache_type', [LRI, LRU])
+@pytest.mark.parametrize('source_type', [dict, iter])
+def test_cache_update_source_and_keywords(cache_type, source_type):
+    cache = cache_type(max_size=2)
+    source = source_type([('a', 1), ('b', 2)])
+
+    assert cache.update(source, a=3) is None
+    assert dict(cache) == {'a': 3, 'b': 2}
+    cache['c'] = 4
+    assert dict(cache) == {'a': 3, 'c': 4}
+
+    with pytest.raises(TypeError):
+        cache.update(None)
+
+
 @pytest.mark.parametrize("lru_class", [LRU, LRI])
 def test_lru_dict_replacement(lru_class):
     # see issue #348


### PR DESCRIPTION
`LRI` and `LRU` currently require a positional argument for `update()`, so `cache.update()` and `cache.update(a=1)` raise `TypeError`. Passing the cache itself also returns before applying keywords, so `cache.update(cache, a=2)` silently leaves the old value unchanged.

Default the positional input to an empty iterable and skip only the self-input portion of an update. Keyword entries continue through `__setitem__`, preserving value replacement, size limits, and eviction ordering.

```python
from boltons.cacheutils import LRU

cache = LRU(max_size=2, values={'a': 1})
cache.update()             # no-op
cache.update(b=2)          # {'a': 1, 'b': 2}
cache.update(cache, a=3)   # {'a': 3, 'b': 2}
```

Tests cover both cache classes, no-op statistics and eviction order, keyword-only updates, self-input with keywords, mapping and one-shot pair inputs, keyword precedence, and explicit `None` rejection. Six regression cases fail before the fix; four compatibility controls pass before and after.

Validation on Python 3.13.14:

- `python -m pytest -q tests/test_cacheutils.py`: 28 passed.
- `python -m pytest -q --doctest-modules boltons tests`: 635 passed.
- `git diff --check`: clean.