### PR TITLE
Complete September PR sweep for 26.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ _(unreleased)_
 - Fixed [`strutils.bytes2human`][strutils.bytes2human] failing to use the `Y` suffix for yottabyte-sized values ([#459](https://github.com/mahmoud/boltons/pull/459))
 - Fixed [`urlutils.URL.get_authority`][urlutils.URL.get_authority] dropping passwords when the username is empty ([#477](https://github.com/mahmoud/boltons/pull/477))
 - Fixed [`strutils.args2sh`][strutils.args2sh] and [`strutils.args2cmd`][strutils.args2cmd] ignoring the `sep` argument ([#454](https://github.com/mahmoud/boltons/pull/454))
+- Fixed [`statsutils.Stats.pearson_type`][statsutils.Stats.pearson_type] raising `RuntimeError` instead of classifying Pearson types IV, V, and VI ([#434](https://github.com/mahmoud/boltons/pull/434))
+- Fixed [`statsutils.Stats.pearson_type`][statsutils.Stats.pearson_type] division by zero at the exact coefficient boundary, preserving the existing Normal and Gamma cases ([#434](https://github.com/mahmoud/boltons/pull/434))
 
 ## 26.1.0
 
@@ -1313,3 +1315,4 @@ added in this release.
 [setutils.IndexedSet.update]: https://boltons.readthedocs.io/en/latest/setutils.html#boltons.setutils.IndexedSet.update
 [strutils.MultiReplace]: https://boltons.readthedocs.io/en/latest/strutils.html#boltons.strutils.MultiReplace
 [setutils.IndexedSet]: https://boltons.readthedocs.io/en/latest/setutils.html#boltons.setutils.IndexedSet
+[statsutils.Stats.pearson_type]: https://boltons.readthedocs.io/en/latest/statsutils.html#boltons.statsutils.Stats.pearson_type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ for an average of one 33-commit release about every 9 weeks. Versions
 are named according to the [CalVer](https://calver.org) versioning
 scheme (`YY.MINOR.MICRO`).
 
-## 26.1.1
+## 26.2.0
 
 _(unreleased)_
 
-- Fixed [`setutils.IndexedSet`][setutils.IndexedSet] updating from multiple iterables to add their elements instead of the iterables themselves
-- Fixed [`strutils.iter_splitlines`][strutils.iter_splitlines] and [`strutils.indent`][strutils.indent] recognizing Unicode line separators instead of splitting on spaces followed by `28` or `29`
+- Added [`statsutils.mode`][statsutils.mode] to return the most common value, breaking ties by first appearance ([#453](https://github.com/mahmoud/boltons/pull/453))
+- Fixed [`setutils.IndexedSet.update`][setutils.IndexedSet.update] adding the iterables themselves instead of their elements when given multiple inputs ([#474](https://github.com/mahmoud/boltons/pull/474))
+- Fixed [`strutils.iter_splitlines`][strutils.iter_splitlines] and [`strutils.indent`][strutils.indent] splitting dates containing ` 28` or ` 29` instead of recognizing Unicode line separators ([#475](https://github.com/mahmoud/boltons/pull/475))
 - Added [`strutils.ellipsize`][strutils.ellipsize] for word-boundary-aware text truncation with an ellipsis
 - Fixed [`funcutils.wraps`][funcutils.wraps] passing arguments positionally to wrappers that only accept them as keywords ([#261](https://github.com/mahmoud/boltons/issues/261))
 - Fixed [`tableutils.Table.to_text`][tableutils.Table] crashes on empty tables, `None` headers, and short header rows; empty headers now render no header row, matching `to_html`
@@ -19,6 +20,32 @@ _(unreleased)_
 - Fixed [`strutils.MultiReplace`][strutils.MultiReplace] raising `KeyError` on empty substitution maps (now a no-op)
 - Fixed [`jsonutils.JSONLIterator`][jsonutils.JSONLIterator] hanging when a seek lands past the last newline, and negative `rel_seek` values seeking past EOF (sign bug)
 - Fixed [`iterutils.xfrange`][iterutils.xfrange] yielding nothing for descending ranges; now shares [`frange`][iterutils.frange]'s count-based semantics, so both agree at inexact float boundaries
+- Fixed [`urlutils.parse_qsl`][urlutils.parse_qsl] ignoring its `encoding` argument when decoding keys and values ([#455](https://github.com/mahmoud/boltons/pull/455))
+- Fixed [`dictutils.OrderedMultiDict.addlist`][dictutils.OrderedMultiDict.addlist] dropping values from one-shot iterables, including the vendored copy in `urlutils` ([#458](https://github.com/mahmoud/boltons/pull/458))
+- Fixed [`ecoutils.get_profile`][ecoutils.get_profile] looking up identifying host, username, and working-directory information when `scrub=True` ([#461](https://github.com/mahmoud/boltons/pull/461))
+- Fixed [`namedutils.namedtuple`][namedutils.namedtuple] and [`namedutils.namedlist`][namedutils.namedlist] raising `IndexError` instead of `ValueError` for empty type and field names ([#462](https://github.com/mahmoud/boltons/pull/462))
+- Fixed [`iterutils.GUIDerator`][iterutils.GUIDerator] error text to reflect the inclusive minimum size of 20 ([#451](https://github.com/mahmoud/boltons/pull/451))
+- Fixed [`timeutils.decimal_relative_time`][timeutils.decimal_relative_time] and `relative_time` rejecting aware datetimes when the comparison time is omitted ([#469](https://github.com/mahmoud/boltons/pull/469))
+- Fixed [`timeutils.USTimeZone`][timeutils.USTimeZone] handling of repeated and missing DST hours, including `fold` on UTC conversion ([#441](https://github.com/mahmoud/boltons/pull/441))
+- Fixed [`mathutils.Bits`][mathutils.Bits] negative indexing ([#450](https://github.com/mahmoud/boltons/pull/450))
+- Fixed [`mathutils.Bits`][mathutils.Bits] empty binary, hexadecimal, and byte round trips ([#468](https://github.com/mahmoud/boltons/pull/468))
+- Sped up [`setutils.IndexedSet`][setutils.IndexedSet] bulk difference and intersection updates with a single-pass rebuild ([#440](https://github.com/mahmoud/boltons/pull/440))
+- Fixed [`listutils.BarrelList`][listutils.BarrelList] out-of-range indexing returning unrelated values ([#440](https://github.com/mahmoud/boltons/pull/440))
+- Fixed [`listutils.BarrelList`][listutils.BarrelList] insertion clamping across multiple internal lists ([#440](https://github.com/mahmoud/boltons/pull/440))
+- Fixed [`listutils.BarrelList`][listutils.BarrelList] popping after an internal list was emptied by indexed removals ([#440](https://github.com/mahmoud/boltons/pull/440))
+- Fixed [`listutils.BarrelList.iter_slice`][listutils.BarrelList.iter_slice] slice normalization and reverse steps ([#471](https://github.com/mahmoud/boltons/pull/471))
+- Fixed [`listutils.BarrelList.del_slice`][listutils.BarrelList.del_slice] deletion across internal lists and through the end of the list ([#472](https://github.com/mahmoud/boltons/pull/472))
+- Fixed [`jsonutils.JSONLIterator`][jsonutils.JSONLIterator] rejecting the documented `rel_seek=1.0` endpoint ([#465](https://github.com/mahmoud/boltons/pull/465))
+- Fixed [`jsonutils.JSONLIterator`][jsonutils.JSONLIterator] relative seeking in binary streams ([#464](https://github.com/mahmoud/boltons/pull/464))
+- Fixed [`statsutils.Stats.get_histogram_counts`][statsutils.Stats.get_histogram_counts] division by zero for data with no interquartile spread ([#467](https://github.com/mahmoud/boltons/pull/467))
+- Fixed [`jsonutils.reverse_iter_lines`][jsonutils.reverse_iter_lines] ignoring explicit and stream encodings ([#463](https://github.com/mahmoud/boltons/pull/463))
+- Fixed [`jsonutils.reverse_iter_lines`][jsonutils.reverse_iter_lines] detaching the caller's text stream, preventing later reads and context-manager cleanup ([#466](https://github.com/mahmoud/boltons/pull/466))
+- Fixed [`cacheutils.ThresholdCounter.update`][cacheutils.ThresholdCounter.update] ignoring mapping and keyword counts ([#476](https://github.com/mahmoud/boltons/pull/476))
+- Fixed [`cacheutils.LRI.update`][cacheutils.LRI.update] and [`cacheutils.LRU.update`][cacheutils.LRU.update] rejecting empty and keyword-only updates, and ignoring keywords when the source is the cache itself ([#478](https://github.com/mahmoud/boltons/pull/478))
+- Fixed [`cacheutils.ThresholdCounter.most_common`][cacheutils.ThresholdCounter.most_common] returning no pairs when the limit is omitted ([#460](https://github.com/mahmoud/boltons/pull/460))
+- Fixed [`strutils.bytes2human`][strutils.bytes2human] failing to use the `Y` suffix for yottabyte-sized values ([#459](https://github.com/mahmoud/boltons/pull/459))
+- Fixed [`urlutils.URL.get_authority`][urlutils.URL.get_authority] dropping passwords when the username is empty ([#477](https://github.com/mahmoud/boltons/pull/477))
+- Fixed [`strutils.args2sh`][strutils.args2sh] and [`strutils.args2cmd`][strutils.args2cmd] ignoring the `sep` argument ([#454](https://github.com/mahmoud/boltons/pull/454))
 
 ## 26.1.0
 
@@ -1268,3 +1295,21 @@ added in this release.
 [urlutils]: http://boltons.readthedocs.org/en/latest/urlutils.html
 [urlutils.SCHEME_PORT_MAP]: http://boltons.readthedocs.org/en/latest/urlutils.html#boltons.urlutils.SCHEME_PORT_MAP
 [urlutils.find_all_links]: http://boltons.readthedocs.org/en/latest/urlutils.html#boltons.urlutils.find_all_links
+[statsutils.mode]: https://boltons.readthedocs.io/en/latest/statsutils.html#boltons.statsutils.mode
+[urlutils.parse_qsl]: https://boltons.readthedocs.io/en/latest/urlutils.html#boltons.urlutils.parse_qsl
+[dictutils.OrderedMultiDict.addlist]: https://boltons.readthedocs.io/en/latest/dictutils.html#boltons.dictutils.OrderedMultiDict.addlist
+[ecoutils.get_profile]: https://boltons.readthedocs.io/en/latest/ecoutils.html#boltons.ecoutils.get_profile
+[namedutils.namedtuple]: https://boltons.readthedocs.io/en/latest/namedutils.html#boltons.namedutils.namedtuple
+[namedutils.namedlist]: https://boltons.readthedocs.io/en/latest/namedutils.html#boltons.namedutils.namedlist
+[timeutils.USTimeZone]: https://boltons.readthedocs.io/en/latest/timeutils.html#boltons.timeutils.USTimeZone
+[cacheutils.ThresholdCounter.update]: https://boltons.readthedocs.io/en/latest/cacheutils.html#boltons.cacheutils.ThresholdCounter.update
+[cacheutils.ThresholdCounter.most_common]: https://boltons.readthedocs.io/en/latest/cacheutils.html#boltons.cacheutils.ThresholdCounter.most_common
+[cacheutils.LRI.update]: https://boltons.readthedocs.io/en/latest/cacheutils.html#boltons.cacheutils.LRI.update
+[cacheutils.LRU.update]: https://boltons.readthedocs.io/en/latest/cacheutils.html#boltons.cacheutils.LRU.update
+[urlutils.URL.get_authority]: https://boltons.readthedocs.io/en/latest/urlutils.html#boltons.urlutils.URL.get_authority
+[statsutils.Stats.get_histogram_counts]: https://boltons.readthedocs.io/en/latest/statsutils.html#boltons.statsutils.Stats.get_histogram_counts
+[listutils.BarrelList.iter_slice]: https://boltons.readthedocs.io/en/latest/listutils.html#boltons.listutils.BarrelList.iter_slice
+[listutils.BarrelList.del_slice]: https://boltons.readthedocs.io/en/latest/listutils.html#boltons.listutils.BarrelList.del_slice
+[setutils.IndexedSet.update]: https://boltons.readthedocs.io/en/latest/setutils.html#boltons.setutils.IndexedSet.update
+[strutils.MultiReplace]: https://boltons.readthedocs.io/en/latest/strutils.html#boltons.strutils.MultiReplace
+[setutils.IndexedSet]: https://boltons.readthedocs.io/en/latest/setutils.html#boltons.setutils.IndexedSet

--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -293,18 +293,17 @@ class LRI(dict):
                 self[key] = default
                 return default
 
-    def update(self, E, **F):
+    def update(self, E=(), **F):
         # E and F are throwback names to the dict() __doc__
         with self._lock:
-            if E is self:
-                return
             setitem = self.__setitem__
-            if callable(getattr(E, 'keys', None)):
-                for k in E.keys():
-                    setitem(k, E[k])
-            else:
-                for k, v in E:
-                    setitem(k, v)
+            if E is not self:
+                if callable(getattr(E, 'keys', None)):
+                    for k in E.keys():
+                        setitem(k, E[k])
+                else:
+                    for k, v in E:
+                        setitem(k, v)
             for k in F:
                 setitem(k, F[k])
             return
@@ -726,7 +725,7 @@ class ThresholdCounter:
         """Get the top *n* keys and counts as tuples. If *n* is omitted,
         returns all the pairs.
         """
-        if not n or n <= 0:
+        if n is not None and n <= 0:
             return []
         ret = sorted(self.iteritems(), key=lambda x: x[1], reverse=True)
         if n is None or n >= len(ret):
@@ -802,8 +801,8 @@ class ThresholdCounter:
         to integer counts.
         """
         if iterable is not None:
-            if callable(getattr(iterable, 'iteritems', None)):
-                for key, count in iterable.iteritems():
+            if callable(getattr(iterable, 'items', None)):
+                for key, count in iterable.items():
                     for i in range(count):
                         self.add(key)
             else:

--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -58,8 +58,8 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
         file_obj (file): An open file object. Note that
             ``reverse_iter_lines`` mutably reads from the file and
             other functions should not mutably interact with the file
-            object after being passed. Files can be opened in bytes or
-            text mode.
+            object during iteration. Files can be opened in bytes or
+            text mode. Seek before reusing a text stream after iteration.
         blocksize (int): The block size to pass to
           :meth:`file.read()`. Warning: keep this a fairly large
           multiple of 2, defaults to 4096.
@@ -69,21 +69,17 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
             file cursor is already in position, either at the end of
             the file or in the middle for relative reverse line
             generation.
+        encoding (str): Text encoding used to decode lines. Defaults to the
+            file's encoding, or returns bytes when neither is specified.
 
     """
     # This function is a bit of a pain because it attempts to be byte/text agnostic
-    try:
-        encoding = encoding or file_obj.encoding
-    except AttributeError:
-        # BytesIO
-        encoding = None
-    else:
-        encoding = 'utf-8'
+    encoding = encoding or getattr(file_obj, 'encoding', None)
 
     # need orig_obj to keep alive otherwise __del__ on the TextWrapper will close the file
     orig_obj = file_obj
     try:
-        file_obj = orig_obj.detach()
+        file_obj = orig_obj.buffer
     except (AttributeError, io.UnsupportedOperation):
         pass
 

--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -552,6 +552,7 @@ DEACCENT_MAP = DeaccenterDict(_BASE_DEACCENT_MAP)
 
 _SIZE_SYMBOLS = ('B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
 _SIZE_BOUNDS = [(1024 ** i, sym) for i, sym in enumerate(_SIZE_SYMBOLS)]
+_SIZE_BOUNDS.append((float('inf'), ''))
 _SIZE_RANGES = list(zip(_SIZE_BOUNDS, _SIZE_BOUNDS[1:]))
 
 
@@ -568,6 +569,8 @@ def bytes2human(nbytes, ndigits=0):
     '0.00B'
     >>> bytes2human(1024)
     '1K'
+    >>> bytes2human(1024 ** 8)
+    '1Y'
     """
     abs_bytes = abs(nbytes)
     for (size, symbol), (next_size, next_symbol) in _SIZE_RANGES:

--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -721,7 +721,7 @@ class URL:
         """
         parts = []
         _add = parts.append
-        if self.username and with_userinfo:
+        if with_userinfo and (self.username or self.password):
             _add(quote_userinfo_part(self.username))
             if self.password:
                 _add(':')

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -471,6 +471,8 @@ def test_threshold_counter():
     assert tc.get_uncommon_count() == 1  # bc the initial 1 was dropped
     assert round(tc.get_commonality(), 2) == 0.92
     assert tc.most_common(2) == [(2, 10), (5, 1)]
+    assert tc.most_common() == [(2, 10), (5, 1)]
+    assert tc.most_common(0) == []
     assert list(tc.elements()) == ([2] * 10) + [5]
 
     assert tc[2] == 10
@@ -478,3 +480,41 @@ def test_threshold_counter():
     assert sorted(tc.keys()) == [2, 5]
     assert sorted(tc.values()) == [1, 10]
     assert sorted(tc.items()) == [(2, 10), (5, 1)]
+
+
+def test_threshold_counter_update_mapping_counts():
+    tc = ThresholdCounter()
+    tc.add('a')
+    tc.update({'a': 3, 'b': 2, 'zero': 0})
+    assert dict(tc.items()) == {'a': 4, 'b': 2}
+    assert tc.total == 6
+
+
+def test_threshold_counter_update_keyword_counts():
+    tc = ThresholdCounter()
+    tc.update(['a'], a=3, b=2, zero=0)
+    assert dict(tc.items()) == {'a': 4, 'b': 2}
+    assert tc.total == 6
+
+
+def test_threshold_counter_update_mapping_compaction():
+    tc = ThresholdCounter(threshold=0.1)
+    expected = ThresholdCounter(threshold=0.1)
+    tc.add('rare')
+    expected.add('rare')
+    tc.update({'a': 10, 'b': 5})
+    expected.update(['a'] * 10 + ['b'] * 5)
+    assert dict(tc.items()) == dict(expected.items())
+    assert tc.total == expected.total == 16
+    assert tc.get_uncommon_count() == expected.get_uncommon_count()
+
+
+@pytest.mark.parametrize('cache_type', [LRI, LRU])
+def test_cache_update_optional_source(cache_type):
+    cache = cache_type(values={'existing': 0})
+    cache.update()
+    assert dict(cache) == {'existing': 0}
+    cache.update(a=1)
+    assert dict(cache) == {'existing': 0, 'a': 1}
+    cache.update(cache, a=2)
+    assert dict(cache) == {'existing': 0, 'a': 2}

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -97,3 +97,26 @@ def test_jsonl_relative_seek_binary_matches_text(tmp_path):
     path.write_bytes(b'{"n": 1}\n{"n": 2}\n{"n": 3}\n')
     with path.open('rb') as binary, path.open() as text:
         assert list(JSONLIterator(binary, rel_seek=0.4)) == list(JSONLIterator(text, rel_seek=0.4))
+
+
+def test_reverse_iter_lines_uses_file_encoding(tmp_path):
+    path = tmp_path / 'latin1.txt'
+    path.write_bytes('café\nfin'.encode('latin-1'))
+    with path.open(encoding='latin-1') as stream:
+        assert list(reverse_iter_lines(stream)) == ['fin', 'café']
+
+
+def test_reverse_iter_lines_uses_explicit_binary_encoding():
+    from io import BytesIO
+
+    stream = BytesIO('café\nfin'.encode('latin-1'))
+    assert list(reverse_iter_lines(stream, encoding='latin-1')) == ['fin', 'café']
+
+
+def test_reverse_iter_lines_keeps_text_stream_attached(tmp_path):
+    path = tmp_path / 'lines.txt'
+    path.write_text('first\nsecond')
+    with path.open() as stream:
+        assert list(reverse_iter_lines(stream)) == ['second', 'first']
+        stream.seek(0)
+        assert stream.read() == 'first\nsecond'

--- a/tests/test_namedutils.py
+++ b/tests/test_namedutils.py
@@ -46,9 +46,3 @@ def test_empty_type_name_raises_value_error(factory):
 def test_invalid_character_still_raises_value_error(factory):
     with pytest.raises(ValueError):
         factory('Point', ['x', 'y-z'])
-
-
-@pytest.mark.parametrize("factory", [namedtuple, namedlist])
-def test_valid_names_still_accepted(factory):
-    cls = factory('Point', ['x', 'y'])
-    assert cls(x=1, y=2).x == 1

--- a/tests/test_statsutils.py
+++ b/tests/test_statsutils.py
@@ -43,4 +43,3 @@ def test_histogram_zero_interquartile_range():
     for data in ([5] * 10, [0] * 10 + [100]):
         counts = Stats(data).get_histogram_counts()
         assert counts == [(float(min(data)), len(data))]
-        assert Stats(data).format_histogram()

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -284,6 +284,7 @@ def test_bytes2human():
     assert b2h(1024 ** 2) == '1M'
     assert b2h(1024 ** 3) == '1G'
     assert b2h(1024 ** 4) == '1T'
+    assert b2h(1024 ** 8) == '1Y'
     # Just below a boundary stays in the smaller unit.
     assert b2h(1023) == '1023B'
     assert b2h(1024 ** 2 - 1, 1) == '1024.0K'

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -199,6 +199,15 @@ def test_userinfo():
     assert url.to_text() == 'http://someuser:somepassword@example.com/some-segment@ignore'
 
 
+def test_password_without_username():
+    url = URL('http://:secret@example.com/path')
+    assert url.to_text() == 'http://:secret@example.com/path'
+    assert url.get_authority(with_userinfo=True) == ':secret@example.com'
+    assert url.get_authority() == 'example.com'
+    url.password = 'p@ss'
+    assert url.to_text(full_quote=True) == 'http://:p%40ss@example.com/path'
+
+
 def test_quoted_userinfo():
     url = URL('http://wikipedia.org')
     url.username = 'user'


### PR DESCRIPTION
## Changes

Fold #463, #466, #476, #478, #460, #459, and #477 with contributor credits.

* Preserve reverse iterator encodings and caller-owned text streams.
* Honor ThresholdCounter mapping counts using items(), without a Python 2 fallback.
* Allow empty and keyword-only LRI/LRU updates. Self-source updates still apply keywords; eviction internals are unchanged.
* Return all pairs from most_common() when its limit is omitted.
* Make the yottabyte suffix reachable.
* Preserve URL passwords when the username is empty.
* Consolidate 26.2.0 release notes, including the separately landed #434 completion and the earlier mode() and separator fixes.

## Verification

* Full local suite: 672 passed (Python 3.14.5), including doctests.
* Each folded fix has a regression that fails against its pre-fix implementation and passes after the maintainer implementation. #459 is covered by its added doctest.
* Verified latin-1 decoding, explicit BytesIO encoding, stream seek/read reuse and context-manager close, mapping counts, cache update/eviction behavior, and URL round trips.
* Removed the legacy-mapping fallback test, duplicate coverage, and non-empty assertions rather than carrying them into the suite.

CI must pass before merge. The folded PRs will be closed with credit after this lands.
