### PR TITLE
Fix FilePerms to revoke previously set permissions

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -150,6 +150,7 @@ class FilePerms:
             for symbol in value:
                 bit = 2 ** key.index(symbol)
                 mode |= (bit << (self.offset * 3))
+            fp_obj._integer &= ~(_SINGLE_FULL_PERM << (self.offset * 3))
             fp_obj._integer |= mode
 
     def __init__(self, user='', group='', other=''):

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,6 +1,8 @@
 import os.path
 import pathlib
 
+import pytest
+
 
 
 from boltons import fileutils
@@ -27,6 +29,21 @@ def test_fileperms():
     assert oct(int(up)) == '0o770'
 
     assert int(FilePerms()) == 0
+
+
+@pytest.mark.parametrize('field', ['user', 'group', 'other'])
+@pytest.mark.parametrize('before', ['', 'r', 'w', 'x', 'rw', 'rx', 'wx', 'rwx'])
+@pytest.mark.parametrize('after', ['', 'r', 'w', 'x', 'rw', 'rx', 'wx', 'rwx'])
+def test_fileperms_replace_field(field, before, after):
+    values = dict(user='rw', group='r', other='x')
+    values[field] = before
+    perms = FilePerms(**values)
+
+    setattr(perms, field, after)
+
+    values[field] = after
+    assert getattr(perms, field) == after
+    assert int(perms) == int(FilePerms(**values))
 
 
 def test_atomicsaver_pathlike(tmp_path):


### PR DESCRIPTION
Setting a `FilePerms` field to fewer permissions currently updates its string value but leaves the removed bits in `int(perms)`. For example, clearing group and other access from `0o644` still gives `0o644` to `os.chmod`.

Clear the field's existing three bits before applying its new value, using the existing permission mask. Add 192 regression cases covering all old/new permission combinations for each field and preservation of the other fields.

Fixes #480.

Validation:
- Before the fix: 111 of the 192 regression cases fail.
- After: 864 tests and doctests pass (`python -m pytest --doctest-modules boltons tests -q`).
- Real temporary file: revoking group/other permissions changes `0o644` to `0o600`; restoring group read access gives `0o640`.
- Verified on macOS with CPython 3.12.13. Other platforms/interpreters were not run locally.

AI assistance was used to prepare the patch and tests; the failure and corrected filesystem behavior were executed locally.
