### PR TITLE
Keep the requested number of rotated file generations

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -716,13 +716,13 @@ def rotate_file(filename, *, keep: int = 5):
         else:
             kept_names.append(f'{fn_root}.{i}')
 
+    if os.path.exists(kept_names[-1]):
+        os.remove(kept_names[-1])
+
     fns = [filename] + kept_names
     for orig_name, kept_name in reversed(list(zip(fns, fns[1:]))):
         if not os.path.exists(orig_name):
             continue
         os.rename(orig_name, kept_name)
-
-    if os.path.exists(kept_names[-1]):
-        os.remove(kept_names[-1])
 
     return

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,6 +1,8 @@
 import os.path
 import pathlib
 
+import pytest
+
 
 
 from boltons import fileutils
@@ -73,7 +75,7 @@ def test_rotate_file_one_rotation(tmp_path):
 def test_rotate_file_full_rotation(tmp_path):
     file_path = tmp_path / 'test_file.txt'
     file_path.write_text('test content 0')
-    for i in range(1, 5):
+    for i in range(1, 6):
         cur_path = tmp_path / f'test_file.{i}.txt'
         cur_path.write_text(f'test content {i}')
         assert cur_path.exists()
@@ -81,16 +83,16 @@ def test_rotate_file_full_rotation(tmp_path):
     fileutils.rotate_file(file_path, keep=5)
     assert not file_path.exists()
 
-    for i in range(1, 5):
+    for i in range(1, 6):
         cur_path = tmp_path / f'test_file.{i}.txt'
         assert cur_path.read_text() == f'test content {i-1}'
 
-    assert not (tmp_path / 'test_file.5.txt').exists()
+    assert not (tmp_path / 'test_file.6.txt').exists()
 
 def test_rotate_file_full_rotation_no_ext(tmp_path):
     file_path = tmp_path / 'test_file'
     file_path.write_text('test content 0')
-    for i in range(1, 5):
+    for i in range(1, 6):
         cur_path = tmp_path / f'test_file.{i}'
         cur_path.write_text(f'test content {i}')
         assert cur_path.exists()
@@ -98,9 +100,24 @@ def test_rotate_file_full_rotation_no_ext(tmp_path):
     fileutils.rotate_file(file_path, keep=5)
     assert not file_path.exists()
 
-    for i in range(1, 5):
+    for i in range(1, 6):
         cur_path = tmp_path / f'test_file.{i}'
         assert cur_path.read_text() == f'test content {i-1}'
 
-    assert not (tmp_path / 'test_file.5').exists()
+    assert not (tmp_path / 'test_file.6').exists()
 
+
+@pytest.mark.parametrize('extension', ['', '.txt'])
+@pytest.mark.parametrize('keep', [1, 2, 5])
+def test_rotate_file_retains_requested_generations(tmp_path, extension, keep):
+    file_path = tmp_path / f'log{extension}'
+    for generation in range(keep + 2):
+        file_path.write_text(f'generation {generation}')
+        fileutils.rotate_file(file_path, keep=keep)
+
+        expected = {
+            f'log.{index}{extension}': f'generation {generation - index + 1}'
+            for index in range(1, min(generation + 1, keep) + 1)
+        }
+        actual = {path.name: path.read_text() for path in tmp_path.iterdir()}
+        assert actual == expected


### PR DESCRIPTION
`rotate_file(path, keep=1)` currently deletes the backup it just created, leaving no copy of the file. For larger values it retains `keep - 1` generations instead of the requested count.

Remove the oldest generation before the descending rename sequence. This lets the new last generation survive. Update the two full-rotation tests to verify all five retained contents (including replacement of a pre-existing fifth backup), and add repeated-rotation tests for `keep=1`, `2`, and `5`, with and without extensions.

Fixes #479.

Validation:
- Before: 8 fileutils scenarios fail; `keep=1` leaves an empty directory.
- After: 678 tests and doctests pass (`python -m pytest --doctest-modules boltons tests -q`).
- Actual temporary files preserve the latest backup, replace the oldest on subsequent rotations, and remain unchanged when the source is missing or `keep=0` is rejected.
- Full suite tested locally on macOS with CPython 3.12.13; focused review tests also passed on Python 3.14. Windows was not tested.

This branch is independent of #482. AI assistance was used for implementation and tests; before/after filesystem behavior was verified locally.
