### PR TITLE
Preserve empty permission fields in FilePerms.from_int

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -169,7 +169,7 @@ class FilePerms:
         i &= FULL_PERMS
         key = ('', 'x', 'w', 'xw', 'r', 'rx', 'rw', 'rwx')
         parts = []
-        while i:
+        for _ in range(3):
             parts.append(key[i & _SINGLE_FULL_PERM])
             i >>= 3
         parts.reverse()

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,6 +1,8 @@
 import os.path
 import pathlib
 
+import pytest
+
 
 
 from boltons import fileutils
@@ -27,6 +29,12 @@ def test_fileperms():
     assert oct(int(up)) == '0o770'
 
     assert int(FilePerms()) == 0
+
+
+@pytest.mark.parametrize('mode', list(range(0o1000)) + [0o1000, 0o7007, 0o100070, -1])
+def test_fileperms_from_int_roundtrip(mode):
+    perms = FilePerms.from_int(mode)
+    assert int(perms) == mode & 0o777
 
 
 def test_atomicsaver_pathlike(tmp_path):


### PR DESCRIPTION
`FilePerms.from_int()` drops leading empty permission groups, shifting group/other permissions into a different class:

```python
>>> perms = FilePerms.from_int(0o007)
>>> repr(perms)
"FilePerms(user='rwx', group='', other='')"
>>> oct(int(perms))
'0o700'
```

The same problem affects `from_path()`, which delegates to `from_int()`. Reading a file's mode and passing `int(perms)` back to `os.chmod` can therefore change its permission classes.

Read exactly three groups instead of stopping when the remaining integer becomes zero. The existing lower-nine-bit mask is unchanged. Add roundtrip coverage for all 512 standard modes plus special-bit/file-type/negative inputs to retain existing masking behavior.

Validation on macOS, CPython 3.12.13:
- Before: 65 of 516 roundtrip cases fail.
- After: 1,188 tests and doctests pass (`python -m pytest --doctest-modules boltons tests -q`).
- Real-file `from_path`/`chmod` roundtrips preserve `0o000`, `0o007`, `0o070`, `0o077`, `0o644`, and `0o777`.
- Toggling original/patched/original code on a real file reproduces `0o007 → 0o700`, preserves `0o007`, and reproduces the failure again.

Independent of #482 (setter updates) and #483 (rotation). AI assistance was used to prepare the patch and tests; runtime behavior was verified locally. Windows and the Python 3.7 runtime were not tested locally.
