### PR TITLE
Fix iter_find_files depth with trailing path separators

### DIFF
--- a/boltons/fileutils.py
+++ b/boltons/fileutils.py
@@ -531,10 +531,12 @@ def iter_find_files(directory, patterns, ignored=None, include_dirs=False, max_d
         ignored = [ignored]
     ign_re = re.compile('|'.join([fnmatch.translate(p) for p in ignored]))
     directory = os.fspath(directory)
-    start_depth = len(directory.split(os.path.sep))
     for root, dirs, files in os.walk(directory):
-        if max_depth is not None and (len(root.split(os.path.sep)) - start_depth) > max_depth:
-            continue
+        if max_depth is not None:
+            relative_root = os.path.relpath(root, directory)
+            depth = 0 if relative_root == os.curdir else relative_root.count(os.path.sep) + 1
+            if depth > max_depth:
+                continue
         if include_dirs:
             for basename in dirs:
                 if pats_re.match(basename):

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -36,6 +36,25 @@ def test_atomicsaver_pathlike(tmp_path):
     assert dest.read_bytes() == b'pathlike works'
 
 
+def test_iter_find_files_max_depth_trailing_separator(tmp_path):
+    (tmp_path / 'root.txt').touch()
+    child = tmp_path / 'child'
+    child.mkdir()
+    (child / 'child.txt').touch()
+    grandchild = child / 'grandchild'
+    grandchild.mkdir()
+    (grandchild / 'deep.txt').touch()
+
+    for max_depth, expected in (
+        (0, {'root.txt'}),
+        (1, {'root.txt', 'child.txt'}),
+    ):
+        for suffix in ('', os.path.sep, os.path.sep * 2):
+            paths = iter_find_files(str(tmp_path) + suffix, '*.txt',
+                                    max_depth=max_depth)
+            assert {os.path.basename(path) for path in paths} == expected
+
+
 def test_iter_find_files_pathlike():
     boltons_path = pathlib.Path(BOLTONS_PATH)
     results = list(iter_find_files(boltons_path, patterns=['*.py']))


### PR DESCRIPTION
A trailing path separator changes the results of iter_find_files when max_depth is set. With root.txt in a directory and child/child.txt below it, max_depth=0 correctly returns only root.txt for the directory path, but also returns child.txt when the same path ends in a separator. Multiple trailing separators let still deeper files through.

The depth calculation subtracts counts of separator-delimited components. Trailing empty components in the initial directory inflate the starting depth. Calculate depth from os.path.relpath(root, directory) instead, so equivalent directory spellings have the same limit.

The regression test builds a real three-level temporary tree and checks max_depth=0 and 1 with zero, one, and two trailing separators. It fails before the fix and passes after it.

Validation on macOS, Python 3.12.13:
- python -m pytest --doctest-modules boltons tests -q: 673 passed.
- git diff --check passed.
