### PR TITLE
Correct complement set symmetric differences

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -788,12 +788,12 @@ class _ComplementSet:
             return NotImplemented
         if self._included is None:
             if exc is None:  # - +
-                return _ComplementSet(excluded=self._excluded - inc)
+                return _ComplementSet(excluded=self._excluded.symmetric_difference(inc))
             else:  # - -
                 return _ComplementSet(included=self._excluded.symmetric_difference(exc))
         else:
             if inc is None:  # + -
-                return _ComplementSet(excluded=exc - self._included)
+                return _ComplementSet(excluded=exc.symmetric_difference(self._included))
             else:  # + +
                 return _ComplementSet(included=self._included.symmetric_difference(inc))
 
@@ -803,13 +803,13 @@ class _ComplementSet:
         inc, exc = _norm_args_typeerror(other)
         if self._included is None:
             if exc is None:  # - +
-                self._excluded |= inc
+                self._excluded.symmetric_difference_update(inc)
             else:  # - -
                 self._excluded.symmetric_difference_update(exc)
                 self._included, self._excluded = self._excluded, None
         else:
             if inc is None:  # + -
-                self._included |= exc
+                self._included.symmetric_difference_update(exc)
                 self._included, self._excluded = None, self._included
             else:  # + +
                 self._included.symmetric_difference_update(inc)

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -194,6 +194,47 @@ def test_complement_set():
     assert opsmash(cab, ops) == ops
 
 
+@mark.parametrize('left_values,right_values', [
+    ({1, 2}, {2, 3}),
+    ({1}, {1}),
+    ({1}, {2}),
+    (set(), {1}),
+    ({1}, set()),
+])
+@mark.parametrize('left_complemented', [False, True])
+@mark.parametrize('right_type', ['set', 'frozenset', 'included', 'excluded'])
+def test_complement_symmetric_difference(left_values, right_values,
+                                        left_complemented, right_type):
+    left = complement(left_values)
+    if not left_complemented:
+        left.complement()
+    if right_type == 'set':
+        right = set(right_values)
+    elif right_type == 'frozenset':
+        right = frozenset(right_values)
+    else:
+        right = complement(right_values)
+        if right_type == 'included':
+            right.complement()
+
+    # Include a value outside both finite inputs to check complement membership.
+    sample = set(range(5))
+    original_left = {value for value in sample if value in left}
+    original_right = {value for value in sample if value in right}
+    expected = original_left ^ original_right
+
+    for result in (left ^ right, right ^ left, left.symmetric_difference(right)):
+        assert {value for value in sample if value in result} == expected
+    assert {value for value in sample if value in left} == original_left
+    assert {value for value in sample if value in right} == original_right
+
+    assert left.symmetric_difference_update(right) is None
+    assert {value for value in sample if value in left} == expected
+    assert {value for value in sample if value in right} == original_right
+    left.symmetric_difference_update(right)
+    assert {value for value in sample if value in left} == original_left
+
+
 def test_iset_index_method():
     original_list = list(range(8, 20)) + list(range(8))
 


### PR DESCRIPTION
`complement({1, 2}) ^ {2, 3}` currently returns `complement({1})`, so it still contains `3` even though `3` belongs to both operands. `symmetric_difference_update()` gives a different wrong result: it leaves `2` excluded although `2` belongs only to the right operand.

Apply symmetric difference to the stored finite sets when exactly one operand is complemented. This follows `(~A) ^ B == ~(A ^ B)` and fixes both the operator and the mutating method.

Add 40 regression cases covering overlapping, identical, disjoint, and empty inputs; ordinary sets, frozensets, and both complement representations; reversed operands; and applying the update twice to restore the original membership. Expected results come from ordinary set operations on sampled membership, including values outside both finite inputs.

Validation on Linux:

- Before the fix: 19 of the 40 regression cases fail.
- Python 3.10.20: `python -m pytest --doctest-modules boltons tests -q` — 712 passed.
- Python 3.14: `uvx --with tox-uv tox -e py314 -- -q` — 712 passed, including package build and doctests.
- `git diff --check` passes.

Made with Astra on Codex