### PR TITLE
Fix reverse line iteration over StringIO streams

### DIFF
--- a/boltons/jsonutils.py
+++ b/boltons/jsonutils.py
@@ -52,7 +52,7 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
     """Returns an iterator over the lines from a file object, in
     reverse order, i.e., last line first, first line last. Uses the
     :meth:`file.seek` method of file objects, and is tested compatible with
-    :class:`file` objects, as well as :class:`StringIO.StringIO`.
+        :class:`file` objects, as well as :class:`io.StringIO`.
 
     Args:
         file_obj (file): An open file object. Note that
@@ -70,7 +70,8 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
             the file or in the middle for relative reverse line
             generation.
         encoding (str): Text encoding used to decode lines. Defaults to the
-            file's encoding, or returns bytes when neither is specified.
+            file's encoding, or returns bytes when neither is specified for
+            a binary stream. Already-decoded text streams return strings.
 
     """
     # This function is a bit of a pain because it attempts to be byte/text agnostic
@@ -83,11 +84,14 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
     except (AttributeError, io.UnsupportedOperation):
         pass
 
-    empty_bytes, newline_bytes, empty_text = b'', b'\n', ''
+    empty = file_obj.read(0)
+    is_text = isinstance(empty, str)
+    newline = '\n' if is_text else b'\n'
+    decode_lines = encoding and not is_text
 
     if preseek:
         file_obj.seek(0, os.SEEK_END)
-    buff = empty_bytes
+    buff = empty
     cur_pos = file_obj.tell()
     while 0 < cur_pos:
         read_size = min(blocksize, cur_pos)
@@ -97,15 +101,15 @@ def reverse_iter_lines(file_obj, blocksize=DEFAULT_BLOCKSIZE, preseek=True, enco
         buff = cur + buff
         lines = buff.splitlines()
 
-        if len(lines) < 2 or lines[0] == empty_bytes:
+        if len(lines) < 2 or lines[0] == empty:
             continue
-        if buff[-1:] == newline_bytes:
-            yield empty_text if encoding else empty_bytes
+        if buff[-1:] == newline:
+            yield '' if decode_lines else empty
         for line in lines[:0:-1]:
-            yield line.decode(encoding) if encoding else line
+            yield line.decode(encoding) if decode_lines else line
         buff = lines[0]
     if buff:
-        yield buff.decode(encoding) if encoding else buff
+        yield buff.decode(encoding) if decode_lines else buff
 
 
 

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -1,4 +1,7 @@
 import os
+from io import StringIO
+
+import pytest
 
 from boltons.jsonutils import (JSONLIterator,
                                DEFAULT_BLOCKSIZE,
@@ -120,3 +123,25 @@ def test_reverse_iter_lines_keeps_text_stream_attached(tmp_path):
         assert list(reverse_iter_lines(stream)) == ['second', 'first']
         stream.seek(0)
         assert stream.read() == 'first\nsecond'
+
+
+@pytest.mark.parametrize('blocksize', [2, DEFAULT_BLOCKSIZE])
+@pytest.mark.parametrize('encoding', [None, 'utf-8'])
+def test_reverse_iter_lines_stringio(blocksize, encoding):
+    text = 'café\nmiddle\nlast\n'
+    with StringIO(text) as stream:
+        assert list(reverse_iter_lines(stream, blocksize=blocksize, encoding=encoding)) == [
+            '', 'last', 'middle', 'café']
+        stream.seek(0)
+        assert stream.read() == text
+
+
+def test_reverse_iter_lines_stringio_preseek_false():
+    with StringIO('café\nmiddle\nlast') as stream:
+        stream.seek(len('café\nmiddle'))
+        assert list(reverse_iter_lines(stream, blocksize=2, preseek=False)) == ['middle', 'café']
+
+
+def test_jsonl_iterator_stringio_reverse():
+    with StringIO('{"name": "café"}\n{"n": 2}\n') as stream:
+        assert list(JSONLIterator(stream, reverse=True)) == [{'n': 2}, {'name': 'café'}]


### PR DESCRIPTION
`reverse_iter_lines(StringIO('first\nsecond'))` raises `TypeError: can only concatenate str (not "bytes") to str`, despite documenting StringIO support. The same failure affects `JSONLIterator(stream, reverse=True)` with an in-memory text stream.

Choose the empty buffer and newline from the stream's `read(0)` result, and decode lines only when the underlying stream returns bytes. This supports already-decoded text streams while preserving the existing binary/text-file encoding path and caller-owned stream lifetime.

Validation: `python -B -m pytest tests/test_jsonutils.py -q` — 15 passed. The six new parameterized cases fail with the original implementation. Coverage includes Unicode StringIO content, small and default blocks, explicit encoding, `preseek=False`, JSONL reverse iteration, and the existing binary/file-encoding tests. `git diff --check` passes. Tested on Windows with Python 3.12; the full multi-version suite was not run.
