### PR TITLE
Normalize absolute destinations in URL.navigate

### DIFF
--- a/boltons/urlutils.py
+++ b/boltons/urlutils.py
@@ -670,7 +670,9 @@ class URL:
         if dest.scheme and dest.host:
             # absolute URLs replace everything, but don't make an
             # extra copy if we don't have to
-            return URL(dest) if orig_dest is None else dest
+            ret = URL(dest) if orig_dest is None else dest
+            ret.normalize()
+            return ret
         query_params = dest.query_params
 
         if dest.path:

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -285,6 +285,20 @@ def test_rel_navigate():
     return
 
 
+@pytest.mark.parametrize('as_url', [False, True])
+def test_navigate_normalizes_absolute_destination(as_url):
+    original = URL('http://example.com/base?old=1')
+    text = 'HTTPS://EXAMPLE.ORG/a/./b/../c?new=2#fragment'
+    destination = URL(text) if as_url else text
+    result = original.navigate(destination)
+
+    assert result.to_text() == 'https://example.org/a/c?new=2#fragment'
+    assert original.to_text() == 'http://example.com/base?old=1'
+    if as_url:
+        assert result is not destination
+        assert destination.path == '/a/./b/../c'
+
+
 def test_navigate():
     orig_text = 'http://a.b/c/d?e#f'
     orig = URL(orig_text)


### PR DESCRIPTION
`URL.navigate()` promises a normalized result, but its absolute-URL fast path returns before normalizing. Navigating to `HTTPS://EXAMPLE.ORG/a/./b/../c` therefore keeps uppercase components and dot segments. Normalize that result before returning it.

Tests cover both string and `URL` destinations, and verify that the caller's destination and base URL remain unchanged. Both regression cases fail on the base revision.

Validation: all 674 tests and module doctests pass on Python 3.12; `git diff --check` passes.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.
