### PR TITLE
Keep LRI and LRU caches consistent during in-place union

### DIFF
--- a/boltons/cacheutils.py
+++ b/boltons/cacheutils.py
@@ -308,6 +308,10 @@ class LRI(dict):
                 setitem(k, F[k])
             return
 
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
     def __eq__(self, other):
         with self._lock:
             if self is other:

--- a/tests/test_cacheutils.py
+++ b/tests/test_cacheutils.py
@@ -24,6 +24,31 @@ def test_lru_add():
     assert 0 not in cache
 
 
+@pytest.mark.parametrize('cache_type', [LRI, LRU])
+@pytest.mark.parametrize('as_pairs', [False, True])
+def test_cache_inplace_union(cache_type, as_pairs):
+    cache = cache_type(max_size=2)
+    cache['old'] = 0
+    original = cache
+    updates = [('first', 1), ('second', 2)]
+    cache |= updates if as_pairs else dict(updates)
+
+    assert cache is original
+    assert dict(cache) == {'first': 1, 'second': 2}
+    assert cache.pop('first') == 1
+    cache['third'] = 3
+    cache['fourth'] = 4
+    assert dict(cache) == {'third': 3, 'fourth': 4}
+
+
+@pytest.mark.parametrize('cache_type', [LRI, LRU])
+def test_cache_inplace_union_self(cache_type):
+    cache = cache_type(max_size=2, values={'first': 1, 'second': 2})
+    cache |= cache
+    cache['third'] = 3
+    assert dict(cache) == {'second': 2, 'third': 3}
+
+
 def test_lri():
     cache_size = 10
     bc = LRI(cache_size, on_miss=lambda k: k.upper())


### PR DESCRIPTION
`LRI` and `LRU` inherit `dict.__ior__`, so `cache |= updates` inserts entries without enforcing capacity or updating the eviction list. The cache can grow past `max_size`, and removing a newly inserted key then raises `KeyError` inside the list bookkeeping.

Route in-place union through the existing `update()` implementation and return the same cache. Regressions cover both cache classes, mappings and iterable pairs, subsequent removal and eviction, and union with the cache itself. The four insertion cases fail on the base revision.

Validation: all 678 tests and module doctests pass on Python 3.12; `git diff --check` passes.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.
