### PR TITLE
Escape the punctuation class so slugify() actually strips backslash

### DIFF
--- a/boltons/strutils.py
+++ b/boltons/strutils.py
@@ -62,7 +62,11 @@ __all__ = ['camel2under', 'under2camel', 'slugify', 'split_punct_ws',
 
 
 _punct_ws_str = string.punctuation + string.whitespace
-_punct_re = re.compile('[' + _punct_ws_str + ']+')
+# re.escape() is required: string.punctuation contains ']', '^', and '\',
+# which are metacharacters inside a character class. Unescaped, the '\]'
+# is read as an escaped bracket rather than two class members, so '\'
+# ends up excluded from the class and is never split on.
+_punct_re = re.compile('[' + re.escape(_punct_ws_str) + ']+')
 _camel2under_re = re.compile('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))')
 
 

--- a/tests/test_strutils.py
+++ b/tests/test_strutils.py
@@ -1,4 +1,5 @@
 import re
+import string
 import uuid
 from unittest import TestCase
 
@@ -44,6 +45,22 @@ def test_asciify():
     b = strutils.asciify(ref)
     assert len(b) == len(b)
     assert b[-1:].decode('ascii') == 'e'
+
+
+def test_slugify_strips_all_punctuation():
+    # string.punctuation contains ']', '^', and '\\', which are
+    # metacharacters inside a regex character class. An earlier
+    # implementation built the class from the raw string, so an
+    # unescaped '\\]' was read as an escaped bracket rather than two
+    # class members, leaving '\\' as the one punctuation character
+    # slugify never stripped.
+    for char in string.punctuation:
+        assert strutils.slugify(f'a{char}b') == 'a_b'
+
+
+def test_slugify_backslash():
+    assert strutils.slugify('a\\b') == 'a_b'
+    assert strutils.slugify(r'C:\Users\file.txt') == 'c_users_file_txt'
 
 
 def test_indent():


### PR DESCRIPTION
## The bug

`_punct_re` builds its character class by interpolating `string.punctuation` straight into `[...]`:

```python
_punct_re = re.compile('[' + string.punctuation + string.whitespace + ']+')
```

`string.punctuation` contains `]`, `^`, and `\` — all metacharacters inside a character class. Specifically, the `\]` pair gets parsed as an *escaped literal bracket*, not as two separate class members. Net effect: `\` is silently excluded from the class, so it's the one punctuation character `slugify()` (and `split_punct_ws()`) never treats as a separator.

```python
>>> slugify(r'C:\Users\file.txt')
'c_\\users\\file_txt'   # every other punctuation char is stripped; backslash isn't
```

This contradicts the docstring's stated goal — "turns text full of scary characters ... into a relatively safe ... string" — and the comment describing the pattern as "punctuation and whitespace." Backslash is punctuation; it's just uniquely mishandled by the unescaped class.

Found by differential/property fuzzing boltons' string utilities against their own documented contracts (checking `slugify`'s output charset), not from a filed issue — I couldn't find a prior report of this one.

## The fix

Wrap the interpolated string in `re.escape()`, which is the normal way to build a character class from an arbitrary string of literal characters:

```python
_punct_re = re.compile('[' + re.escape(_punct_ws_str) + ']+')
```

```python
>>> slugify(r'C:\Users\file.txt')
'c_users_file_txt'
```

## Verification

- All 32 `string.punctuation` characters now individually produce the same normalized output (`slugify('a' + c + 'b') == 'a_b'` for every one).
- The existing `slugify`/`split_punct_ws` doctest examples are unaffected.
- `pytest --doctest-modules boltons/ tests/` (the exact command `tox.ini` runs): 674 passed, before and after.
- Added `test_slugify_strips_all_punctuation` and `test_slugify_backslash` in the existing `assert`-based style of `tests/test_strutils.py`. Confirmed both fail against the unpatched code (reverted locally to check) and pass with the fix — not just "looks right."

Diff is a single explanatory comment + one-token fix in `strutils.py`, plus the two new tests. No behavior change to anything except the one previously-un-splittable character.

---
AI-assisted (Code Puppy); found via fuzzing, root-caused, fixed, and verified by hand before opening this.
