### PR TITLE
Document datetime support in daterange

### DIFF
--- a/boltons/timeutils.py
+++ b/boltons/timeutils.py
@@ -309,18 +309,20 @@ def strpdate(string, format):
 
 def daterange(start, stop, step=1, inclusive=False):
     """In the spirit of :func:`range` and :func:`xrange`, the `daterange`
-    generator that yields a sequence of :class:`~datetime.date`
-    objects, starting at *start*, incrementing by *step*, until *stop*
-    is reached.
+    generator yields a sequence of :class:`~datetime.date` or
+    :class:`~datetime.datetime` objects, starting at *start*, incrementing
+    by *step*, until *stop* is reached. With a :class:`~datetime.datetime`
+    start, the yielded values are also datetimes. Use compatible types
+    for *start* and *stop*, including their timezone awareness.
 
     When *inclusive* is True, the final date may be *stop*, **if**
     *step* falls evenly on it. By default, *step* is one day. See
     details below for many more details.
 
     Args:
-        start (datetime.date): The starting date The first value in
-            the sequence.
-        stop (datetime.date): The stopping date. By default not
+        start (datetime.date or datetime.datetime): The starting date or
+            datetime, and the first value in the sequence.
+        stop (datetime.date or datetime.datetime): The stopping value. By default not
             included in return. Can be `None` to yield an infinite
             sequence.
         step (int): The value to increment *start* by to reach
@@ -357,6 +359,12 @@ def daterange(start, stop, step=1, inclusive=False):
     datetime.date(2017, 6, 1)
     datetime.date(2017, 7, 1)
     datetime.date(2017, 8, 1)
+
+    Datetime inputs also support sub-day :class:`~datetime.timedelta` steps:
+
+    >>> list(daterange(datetime(2020, 1, 1, 9), datetime(2020, 1, 1, 12),
+    ...                step=timedelta(hours=1)))
+    [datetime.datetime(2020, 1, 1, 9, 0), datetime.datetime(2020, 1, 1, 10, 0), datetime.datetime(2020, 1, 1, 11, 0)]
 
     *Be careful when using stop=None, as this will yield an infinite
     sequence of dates.*


### PR DESCRIPTION
## The change

Fixes #91. Document that `timeutils.daterange()` accepts `datetime` inputs and yields datetimes when started with one. Clarify compatible start/stop types and add an executable example using hourly `timedelta` steps. Runtime behavior is unchanged.

Validation on Python 3.10.12:

- `python -m pytest tests/test_timeutils.py -q`: 13 passed, including the existing hourly datetime test.
- `python -m doctest boltons/timeutils.py`: passed, including the new example.
- `git diff --check`: passed.

The full test suite and Sphinx build were not run for this docstring change.

## The backstory

This draft was prepared as the first real contribution for an AI-assisted open-source contribution workflow. Issue #91 was found by reviewing open issues, then checked against the current implementation and its existing datetime test; it was not a problem encountered in an application using boltons.

## AI assistance

- Harness/tooling: Codex running in Kern, with git, pytest and Python doctest.
- Model(s): GPT-6.

The agent selected issue #91, prepared this documentation patch and draft description, and ran the checks above.
