### PR TITLE
Fix zero- and multi-input IndexedSet updates

### DIFF
--- a/boltons/setutils.py
+++ b/boltons/setutils.py
@@ -368,8 +368,9 @@ class IndexedSet(MutableSet):
             self.add(o)
 
     def intersection_update(self, *others):
-        "intersection_update(*others) -> discard self.difference(*others)"
-        to_remove = self.difference(*others)
+        "intersection_update(*others) -> keep items present in every other set"
+        to_remove = self.from_iterable(
+            item for item in self if any(item not in other for other in others))
         if len(to_remove) > _MAX_DEAD_INTERVALS:
             self._bulk_discard(to_remove)
             return
@@ -377,10 +378,9 @@ class IndexedSet(MutableSet):
             self.discard(val)
 
     def difference_update(self, *others):
-        "difference_update(*others) -> discard self.intersection(*others)"
-        if self in others:
-            self.clear()
-        to_remove = self.intersection(*others)
+        "difference_update(*others) -> discard items present in any other set"
+        to_remove = self.from_iterable(
+            item for item in self if any(item in other for other in others))
         if len(to_remove) > _MAX_DEAD_INTERVALS:
             self._bulk_discard(to_remove)
             return

--- a/tests/test_setutils.py
+++ b/tests/test_setutils.py
@@ -331,3 +331,51 @@ def test_small_difference_update_unchanged():
     thing = IndexedSet(range(100))
     thing.difference_update({1, 3, 5})
     assert list(thing)[:5] == [0, 2, 4, 6, 7]
+
+
+@mark.parametrize('method', ['difference_update', 'intersection_update'])
+@mark.parametrize('others', [
+    (),
+    ({1, 2}, {2, 3}),
+    ({1}, {3}),
+    (set(), {1, 2}),
+    ({1, 2}, {2, 3}, {2, 4}),
+])
+def test_indexed_set_update_set_operations_match_builtin(method, others):
+    original = [3, 1, 4, 2]
+    items = IndexedSet(original)
+    expected = set(original)
+    getattr(expected, method)(*others)
+
+    result = getattr(items, method)(*others)
+
+    assert result is None
+    assert list(items) == [value for value in original if value in expected]
+    assert [items[i] for i in range(len(items))] == list(items)
+
+
+@mark.parametrize('method', ['difference_update', 'intersection_update'])
+def test_indexed_set_multiple_update_uses_bulk_removal(method):
+    original = list(range(1000))
+    others = [set(range(600)), set(range(400, 800))]
+    items = IndexedSet(original)
+    expected = set(original)
+    getattr(expected, method)(*others)
+
+    getattr(items, method)(*others)
+
+    assert list(items) == [value for value in original if value in expected]
+    assert items[0] == min(expected)
+    assert items[-1] == max(expected)
+    assert items.index(max(expected)) == len(items) - 1
+
+
+@mark.parametrize('method', ['difference_update', 'intersection_update'])
+def test_indexed_set_update_with_self(method):
+    items = IndexedSet([3, 1, 4, 2])
+    expected = set(items)
+    getattr(expected, method)(expected, {1, 2})
+
+    getattr(items, method)(items, {1, 2})
+
+    assert list(items) == [value for value in [3, 1, 4, 2] if value in expected]


### PR DESCRIPTION
## The change

Fix `IndexedSet.difference_update()` and `intersection_update()` when given zero or multiple input sets. Calling either without arguments currently empties the set. With `{1, 2, 3, 4}` and inputs `{1, 2}`, `{2, 3}`, difference update leaves `{1, 3, 4}` instead of `{4}`, while intersection update leaves `{1, 2, 3}` instead of `{2}`.

Compute the removal set using membership in any input (difference) or absence from any input (intersection), before mutating the receiver. This preserves insertion order and the existing bulk-removal path. Fourteen regression/control cases cover empty argument lists, overlapping and disjoint inputs, empty sets, self operands, and large removals. Thirteen fail on the original implementation; all 686 tests and doctests pass on Windows with Python 3.12.10.

## The backstory

I asked Codex to look for small, verifiable bug fixes in open-source projects. In Boltons, that led to comparing IndexedSet with Python's built-in set and finding these zero- and multi-input discrepancies. I’m submitting this fix because the behavior is easy to reproduce and the change fits Boltons’ aim of following standard-library conventions while preserving insertion order.

## AI assistance

- Harness/tooling: OpenAI Codex.
- Model(s): GPT-6.
- Original prompt(s): “算了你直接代替这个角色为我工作吧，你现在就是高级软件工程师，经常活跃于github，乐于提交各种pr，现在你检索一下，有潜力，高星，或者新项目，有哪些可以提交你能快速完成或有价值的pr” Follow-up after the previous contribution: “继续”. For drafting and submission: “你直接帮我撰写提交就行就行”.

The defect was found during this requested review of contribution opportunities, rather than reported as a production incident. Codex inspected the implementation, reproduced the incorrect results, wrote and ran the tests, prepared the fix, and drafted this PR.
