### PR TITLE
Keep Bits length non-negative after oversized right shifts

### DIFF
--- a/boltons/mathutils.py
+++ b/boltons/mathutils.py
@@ -199,7 +199,7 @@ class Bits:
         return Bits(self.val << other, self.len + other)
 
     def __rshift__(self, other):
-        return Bits(self.val >> other, self.len - other)
+        return Bits(self.val >> other, max(0, self.len - other))
 
     def __hash__(self):
         return hash(self.val)

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -1,4 +1,4 @@
-from pytest import raises
+from pytest import raises, mark
 from boltons.mathutils import clamp, ceil, floor, Bits
 import math
 
@@ -127,6 +127,33 @@ def test_bits_len_bound():
         Bits(4, 2)
     with raises(ValueError):
         Bits(1, 0)
+
+
+@mark.parametrize('value, shift, expected', [
+    ('101', 0, '101'),
+    ('101', 1, '10'),
+    ('0010', 1, '001'),
+    ('101', 3, ''),
+    ('101', 4, ''),
+    ('101', 1024, ''),
+    ('101', 1000000, ''),
+    ('', 0, ''),
+    ('', 1, ''),
+    ('0', 2, ''),
+])
+def test_bits_right_shift(value, shift, expected):
+    bits = Bits(value)
+    result = bits >> shift
+    assert len(result) == len(expected)
+    assert result.as_bin() == expected
+    assert result.as_int() == bits.as_int() >> shift
+    assert result == Bits(expected)
+    assert bits.as_bin() == value
+
+
+def test_bits_right_shift_negative():
+    with raises(ValueError):
+        Bits('101') >> -1
 
 
 def test_empty_bits_conversions():


### PR DESCRIPTION
## The change

Keep the length of a right-shifted `Bits` at zero once all bits have been shifted out. `Bits('101') >> 4` currently creates an object with length -1, so `len(result)` raises `ValueError`; very large shifts can fail during construction instead. Shifting by exactly the original length already returns an empty bit string, and this extends that behavior to larger shifts.

Clamp the resulting length without changing the integer shift. Add tests for ordinary shifts, leading zeros, exact-width and oversized shifts, empty inputs, and negative shift counts.

Validation: `python -m pytest --doctest-modules boltons tests -q` passes all 683 tests on Windows with Python 3.10.20, 3.11.15, 3.12.10, 3.13.14 and 3.14.7. Before the fix, five new boundary cases fail and six control cases pass. `git diff --check` passes. Python 3.14 emits five deprecation warnings in unchanged tests. Older Python versions, PyPy and other platforms were not run locally.

## The backstory

Earlier contribution: #494, which is still awaiting review. This issue was found while continuing the same user-authorized code review, checking whether bit-string boundary operations preserve a usable object. It was found by inspection and local reproduction, not through production usage.

## AI assistance

- Harness/tooling: Codex desktop, Git, Python and pytest.
- Model(s): GPT-6 via Codex.
- Original prompt(s), as close to verbatim as possible:
  - “算了你直接代替这个角色为我工作吧，你现在就是高级软件工程师，经常活跃于github，乐于提交各种pr，现在你检索一下，有潜力，高星，或者新项目，有哪些可以提交你能快速完成或有价值的pr”
  - “你直接帮我撰写提交就行就行”
  - “继续”

Codex selected this case, wrote the patch and tests, ran the checks above, and drafted this description under that authorization.
