### PR TITLE
Fix inferred backoff count for zero starts and fractional stops

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -599,6 +599,12 @@ def backoff_iter(start, stop, count=None, factor=2.0, jitter=False):
     >>> list(backoff_iter(0.25, 100.0, factor=10))
     [0.25, 2.5, 25.0, 100.0]
 
+    A zero *start* yields an immediate retry, followed by a delay of 1,
+    capped at *stop*:
+
+    >>> list(backoff_iter(0, 0.5))
+    [0.0, 0.5]
+
     A simplified usage example:
 
     .. code-block:: python
@@ -620,7 +626,7 @@ def backoff_iter(start, stop, count=None, factor=2.0, jitter=False):
 
     Args:
 
-        start (float): Positive number for baseline.
+        start (float): Nonnegative number for baseline.
         stop (float): Positive number for maximum.
         count (int): Number of steps before stopping
             iteration. Defaults to the number of steps between *start* and
@@ -648,7 +654,7 @@ def backoff_iter(start, stop, count=None, factor=2.0, jitter=False):
     if stop < start:
         raise ValueError('expected stop >= start, not %r' % stop)
     if count is None:
-        denom = start if start else 1
+        denom = start if start else min(stop, 1.0)
         if factor == 1.0:
             if start != stop:
                 raise ValueError('expected factor > 1.0 when count is None'

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -474,6 +474,16 @@ def test_backoff_zero_start():
     assert slow_backoff == [0.0, 1.0, 1.2, 1.44, 1.73, 2.07, 2.49, 2.9]
 
 
+@pytest.mark.parametrize('stop', [0.1, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize('factor', [1.2, 2.0, 10.0])
+def test_backoff_zero_start_fractional_stop(stop, factor):
+    from boltons.iterutils import backoff, backoff_iter
+
+    expected = [0.0, stop]
+    assert backoff(0, stop, factor=factor) == expected
+    assert list(backoff_iter(0, stop, factor=factor)) == expected
+
+
 def test_backoff_validation():
     from boltons.iterutils import backoff
 


### PR DESCRIPTION
## The change

Make `backoff(0, stop)` and `backoff_iter(0, stop)` reach a positive fractional `stop` when the iteration count is inferred. For example, `backoff(0, 0.5)` now yields `[0.0, 0.5]`; the current implementation yields `[0.0]`. Smaller limits can produce an empty sequence or a `ValueError` for a negative inferred count.

The generator advances from zero to `min(1, stop)`. Use that same value when calculating the remaining number of steps. Add a documented example and regression coverage across five stop values and three growth factors.

Validation on Windows with Python 3.13.13:

- New regression cases against the original implementation: 7 failed, 8 passed.
- `python -m pytest tests/test_iterutils.py boltons/iterutils.py --doctest-modules -q`: 101 passed.
- `python -m pytest tests boltons --doctest-modules -q`: 687 passed.
- `git diff --check`: passed.

## The backstory

I asked Codex to investigate and submit small, tested fixes in established open-source projects on my behalf. Boltons was selected for its self-contained Python utilities and its published guidance for AI-assisted contributions. This edge case surfaced during source review and local testing of zero-start backoff behavior. The useful finding was that the inferred count and the generator's actual first step use different baselines when the maximum delay is below one.

## AI assistance

- Harness/tooling: OpenAI Codex desktop, including a delegated coding agent and local Git, Python, and pytest tools.
- Model: GPT-6, as identified in this Codex session.
- Initial discovery request (summary): find and submit tested contributions to established open-source projects with more than 500 stars, preferably with many contributors, using the account owner's GitHub identity.
- Bug-specific follow-up prompt used for an additional technical verification pass, verbatim. This prompt was written after discovery of the edge case:

  > 请对 boltons.iterutils.backoff 的一个具体边界问题进行独立技术复核：默认 count 且 start=0 时，backoff(0, 0.5) 漏掉最终上限，backoff(0, 0.1) 会报错。请从 backoff_iter 的状态推进与默认次数推导出发，解释零起点如何推进到 min(1, stop)、对数公式为何产生错误次数，并验证将推导基准设为 start if start else min(stop, 1.0) 是否与生成器保持一致。核对 0<stop<1、stop=1、stop>1、非零起点、不同 factor、显式 count、jitter、无效参数等边界，使用本地安全有界的测试；区分已有缺陷与该修复引入的变化。给出根因解释、最小修复审查结论及真实测试结果。请只读代码并把复核记录保存在工作区贡献报告中，保持当前代码和分支不变。

  English summary: Review the zero-start fractional-stop defect by comparing the generator's state transitions with the inferred count. Verify the proposed baseline against fractional and larger limits, positive starts, different factors, explicit counts, jitter, and invalid parameters. Use bounded local checks, distinguish existing numerical edge cases from changes introduced by the patch, and report the root cause and actual results while keeping the candidate code unchanged.
