### PR TITLE
Recalculate headerless table width when extending rows

### DIFF
--- a/boltons/tableutils.py
+++ b/boltons/tableutils.py
@@ -279,7 +279,7 @@ class Table:
         if not data:
             return
         self._data.extend(data)
-        self._set_width()
+        self._set_width(reset=not self.headers)
         self._fill()
 
     def _set_width(self, reset=False):

--- a/tests/test_tableutils.py
+++ b/tests/test_tableutils.py
@@ -85,3 +85,31 @@ def test_to_text_short_headers_padded():
     lines = t.to_text().splitlines()
     header_cells = [c.strip() for c in lines[0].split(' | ')]
     assert header_cells == ['a', 'None']
+
+
+def test_extend_headerless_table_with_wider_rows():
+    table = Table([[1]], headers=None)
+    table.extend([[2, 3]])
+
+    assert list(table) == [[1, None], [2, 3]]
+    assert [[cell.strip() for cell in line.split(' | ')]
+            for line in table.to_text().splitlines()] == [['1', 'None'], ['2', '3']]
+    assert table.to_html(orientation='vertical') == (
+        '<table>\n'
+        '<tr><td>1</td><td>2</td></tr>\n'
+        '<tr><td>None</td><td>3</td></tr>\n'
+        '</table>'
+    )
+
+
+def test_extend_headerless_table_preserves_width_for_shorter_rows():
+    table = Table([[1, 2]], headers=None)
+    table.extend([[3]])
+    table.extend(iter([[4, 5, 6]]))
+    table.extend(iter([]))
+
+    assert list(table) == [[1, 2, None], [3, None, None], [4, 5, 6]]
+    assert [[cell.strip() for cell in line.split(' | ')]
+            for line in table.to_text().splitlines()] == [
+        ['1', '2', 'None'], ['3', 'None', 'None'], ['4', '5', '6']
+    ]


### PR DESCRIPTION
## The change

Extending a headerless table with a wider row leaves its cached width unchanged. For example:

```python
table = Table([[1]], headers=None)
table.extend([[2, 3]])
```

`table.to_text()` raises `IndexError`, and `table.to_html(orientation='vertical')` omits the second column. Recalculate the width when extending a headerless table so the existing filling step pads earlier rows. Tables with headers keep their current width behavior.

Two regression tests cover wider rows, shorter rows, iterator inputs, empty extensions, and the text and vertical HTML output. Both fail before the fix. On Linux with CPython 3.14.2, `uv run --group dev pytest --doctest-modules boltons tests -q` passes all 674 tests and doctests. `git diff --check` also passes.

## The backstory

This is my first contribution to boltons. I wanted to support an open-source project with a concrete bug fix; this was found during a source review, rather than through a production incident. The useful finding here was that extending a table updates its rows but can leave the renderers using the old column count.

## AI assistance

Tool: OpenAI Codex

Model: GPT-6

Original user request (relevant excerpt, translated from Russian): “You can look at projects across any tech stack. Look for vulnerabilities and bugs so we can support open source and help improve these projects.”

Codex investigated the bug, prepared the patch and regression tests, and ran the checks locally. Both new tests failed before the fix; all 674 tests passed afterward.
